### PR TITLE
Ugly fix for migration error on tenant

### DIFF
--- a/database/migrations/2015_05_19_000000_hws_ssl_certificates_table.php
+++ b/database/migrations/2015_05_19_000000_hws_ssl_certificates_table.php
@@ -13,34 +13,37 @@ class HwsSslCertificatesTable extends Migration
      */
     public function up()
     {
-        Schema::connection(DatabaseConnection::systemConnectionName())->create('ssl_certificates', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            // tenant owner
-            $table->bigInteger('tenant_id')->unsigned();
+        if (!Schema::connection(DatabaseConnection::systemConnectionName())->hasTable('ssl_certificates')) {
+            Schema::connection(DatabaseConnection::systemConnectionName())->create('ssl_certificates',
+                function (Blueprint $table) {
+                    $table->bigIncrements('id');
+                    // tenant owner
+                    $table->bigInteger('tenant_id')->unsigned();
 
-            // certificate
-            $table->text('certificate');
-            // bundles
-            $table->text('authority_bundle');
-            // key
-            $table->text('key');
+                    // certificate
+                    $table->text('certificate');
+                    // bundles
+                    $table->text('authority_bundle');
+                    // key
+                    $table->text('key');
 
-            $table->boolean('wildcard')->default(false);
+                    $table->boolean('wildcard')->default(false);
 
-            // date when certificate becomes usable as read from certificate
-            $table->timestamp('validates_at')->nullable();
-            // date of expiry as read from certificate
-            $table->timestamp('invalidates_at')->nullable();
+                    // date when certificate becomes usable as read from certificate
+                    $table->timestamp('validates_at')->nullable();
+                    // date of expiry as read from certificate
+                    $table->timestamp('invalidates_at')->nullable();
 
-            // timestaps
-            $table->timestamps();
-            $table->softDeletes();
+                    // timestaps
+                    $table->timestamps();
+                    $table->softDeletes();
 
-            // relations
-            $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('cascade');
+                    // relations
+                    $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('cascade');
 
-            // index
-        });
+                    // index
+                });
+        }
     }
 
     /**
@@ -50,6 +53,8 @@ class HwsSslCertificatesTable extends Migration
      */
     public function down()
     {
-        Schema::connection(DatabaseConnection::systemConnectionName())->dropIfExists('ssl_certificates');
+        if (Schema::connection(DatabaseConnection::systemConnectionName())->hasTable('ssl_certificates')) {
+            Schema::connection(DatabaseConnection::systemConnectionName())->dropIfExists('ssl_certificates');
+        }
     }
 }

--- a/database/migrations/2015_05_19_000001_hws_ssl_hostnames_table.php
+++ b/database/migrations/2015_05_19_000001_hws_ssl_hostnames_table.php
@@ -13,27 +13,30 @@ class HwsSslHostnamesTable extends Migration
      */
     public function up()
     {
-        Schema::connection(DatabaseConnection::systemConnectionName())->create('ssl_hostnames', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            // certificate id
-            $table->bigInteger('ssl_certificate_id')->unsigned();
-            // domain relation
-            $table->bigInteger('hostname_id')->unsigned();
+        if (!Schema::connection(DatabaseConnection::systemConnectionName())->hasTable('ssl_hostnames')) {
+            Schema::connection(DatabaseConnection::systemConnectionName())->create('ssl_hostnames',
+                function (Blueprint $table) {
+                    $table->bigIncrements('id');
+                    // certificate id
+                    $table->bigInteger('ssl_certificate_id')->unsigned();
+                    // domain relation
+                    $table->bigInteger('hostname_id')->unsigned();
 
-            // certificate
-            $table->string('hostname');
+                    // certificate
+                    $table->string('hostname');
 
-            // timestaps
-            $table->timestamps();
-            $table->softDeletes();
+                    // timestaps
+                    $table->timestamps();
+                    $table->softDeletes();
 
-            // index
-            $table->index('hostname');
-            $table->index('hostname_id');
-            $table->index('ssl_certificate_id');
-            // relations
-            $table->foreign('ssl_certificate_id')->references('id')->on('ssl_certificates')->onDelete('cascade');
-        });
+                    // index
+                    $table->index('hostname');
+                    $table->index('hostname_id');
+                    $table->index('ssl_certificate_id');
+                    // relations
+                    $table->foreign('ssl_certificate_id')->references('id')->on('ssl_certificates')->onDelete('cascade');
+                });
+        }
     }
 
     /**
@@ -43,6 +46,8 @@ class HwsSslHostnamesTable extends Migration
      */
     public function down()
     {
-        Schema::connection(DatabaseConnection::systemConnectionName())->dropIfExists('ssl_hostnames');
+        if (!Schema::connection(DatabaseConnection::systemConnectionName())->hasTable('ssl_hostnames')) {
+            Schema::connection(DatabaseConnection::systemConnectionName())->dropIfExists('ssl_hostnames');
+        }
     }
 }


### PR DESCRIPTION
This prevent the below error from occurring when issuing `php artisan migrate --tenant=1`

```
☁  application [master] ⚡ php artisan migrate --tenant=1
Migrating for 1: app-rallyh
Migration table created successfully.
Migration failed for existing table; probably a system migration: SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'ssl_certificates' already exists (SQL: create table `ssl_certificates` (`id` bigint unsigned not null auto_increment primary key, `tenant_id` bigint unsigned not null, `certificate` text not null, `authority_bundle` text not null, `key` text not null, `wildcard` tinyint(1) not null default '0', `validates_at` timestamp null, `invalidates_at` timestamp null, `created_at` timestamp null, `updated_at` timestamp null, `deleted_at` timestamp null) default character set utf8 collate utf8_unicode_ci)

☁  application [master] ⚡ php artisan migrate --tenant=1
Migrating for 1: app-rallyh
Migration table created successfully.
Migration failed for existing table; probably a system migration: SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'ssl_hostnames' already exists (SQL: create table `ssl_hostnames` (`id` bigint unsigned not null auto_increment primary key, `ssl_certificate_id` bigint unsigned not null, `hostname_id` bigint unsigned not null, `hostname` varchar(255) not null, `created_at` timestamp null, `updated_at` timestamp null, `deleted_at` timestamp null) default character set utf8 collate utf8_unicode_ci)
```
