### PR TITLE
Change loadViews to prepend tenant location so customized views will have priority

### DIFF
--- a/src/Tenancy/Tenant/Directory.php
+++ b/src/Tenancy/Tenant/Directory.php
@@ -214,7 +214,7 @@ class Directory implements DirectoryContract
     protected function loadViews($app)
     {
         if (!$this->disallowed('views') && $this->views() && File::isDirectory($this->views())) {
-            $app['view']->addLocation($this->views());
+            $app['view']->getFinder()->prependLocation($this->views());
         }
     }
 


### PR DESCRIPTION
As mentioned on issue #152, it seems like a good idea to assume whenever a tenant-view exists, it should override the default system-view (otherwise why make the tenant view at all?). 

The change here is to simply `prepend` the tenant-view location path instead of just appending it. That way, when finding a view file, Laravel Finder will automatically take the tenant-view first, thus allowing the tenant to have precedence.

I was not able to come up with a Test Code for this small change, unfortunately.
