### PR TITLE
Improved validation of hostnames

### DIFF
--- a/src/Events/Hostnames/Deleting.php
+++ b/src/Events/Hostnames/Deleting.php
@@ -1,0 +1,9 @@
+<?php
+namespace Hyn\Tenancy\Events\Hostnames;
+
+use Hyn\Tenancy\Abstracts\HostnameEvent;
+
+class Deleting extends HostnameEvent
+{
+
+}

--- a/src/Validators/HostnameValidator.php
+++ b/src/Validators/HostnameValidator.php
@@ -23,7 +23,7 @@ class HostnameValidator extends Validator
         'redirect_to' => ['nullable', 'string', 'url'],
         'force_https' => ['boolean'],
         'under_maintenance_since' => ['nullable', 'date'],
-        'website_id' => ['integer', 'nullable', 'exists:%system%.websites,id'],
+        'website_id' => ['nullable', 'integer', 'exists:%system%.websites,id'],
         'customer_id' => ['nullable', 'integer', 'exists:%system%.customers,id'],
     ];
 
@@ -33,7 +33,7 @@ class HostnameValidator extends Validator
         'redirect_to' => ['nullable', 'string', 'url'],
         'force_https' => ['boolean'],
         'under_maintenance_since' => ['nullable', 'date'],
-        'website_id' => ['integer', 'nullable', 'exists:%system%.websites,id'],
+        'website_id' => ['nullable', 'integer', 'exists:%system%.websites,id'],
         'customer_id' => ['nullable', 'integer', 'exists:%system%.customers,id'],
     ];
 }

--- a/src/Validators/HostnameValidator.php
+++ b/src/Validators/HostnameValidator.php
@@ -20,20 +20,20 @@ class HostnameValidator extends Validator
 {
     protected $create = [
         'fqdn' => ['required', 'string', 'unique:%system%.hostnames,fqdn'],
-        'redirect_to' => ['string', 'url'],
+        'redirect_to' => ['nullable','string', 'url'],
         'force_https' => ['boolean'],
-        'under_maintenance_since' => ['date'],
+        'under_maintenance_since' => ['nullable', 'date'],
         'website_id' => ['integer', 'exists:%system%.websites,id'],
-        'customer_id' => ['integer', 'exists:%system%.customers,id'],
+        'customer_id' => ['nullable','integer', 'exists:%system%.customers,id'],
     ];
 
     protected $update = [
         'id' => ['required', 'integer'],
         'fqdn' => ['required', 'string', 'unique:%system%.hostnames,fqdn'],
-        'redirect_to' => ['string', 'url'],
+        'redirect_to' => ['nullable','string', 'url'],
         'force_https' => ['boolean'],
-        'under_maintenance_since' => ['date'],
+        'under_maintenance_since' => ['nullable', 'date'],
         'website_id' => ['integer', 'exists:%system%.websites,id'],
-        'customer_id' => ['integer', 'exists:%system%.customers,id'],
+        'customer_id' => ['nullable','integer', 'exists:%system%.customers,id'],
     ];
 }

--- a/src/Validators/HostnameValidator.php
+++ b/src/Validators/HostnameValidator.php
@@ -20,20 +20,20 @@ class HostnameValidator extends Validator
 {
     protected $create = [
         'fqdn' => ['required', 'string', 'unique:%system%.hostnames,fqdn'],
-        'redirect_to' => ['nullable','string', 'url'],
+        'redirect_to' => ['nullable', 'string', 'url'],
         'force_https' => ['boolean'],
         'under_maintenance_since' => ['nullable', 'date'],
-        'website_id' => ['integer', 'exists:%system%.websites,id'],
-        'customer_id' => ['nullable','integer', 'exists:%system%.customers,id'],
+        'website_id' => ['integer', 'nullable', 'exists:%system%.websites,id'],
+        'customer_id' => ['nullable', 'integer', 'exists:%system%.customers,id'],
     ];
 
     protected $update = [
         'id' => ['required', 'integer'],
         'fqdn' => ['required', 'string', 'unique:%system%.hostnames,fqdn'],
-        'redirect_to' => ['nullable','string', 'url'],
+        'redirect_to' => ['nullable', 'string', 'url'],
         'force_https' => ['boolean'],
         'under_maintenance_since' => ['nullable', 'date'],
-        'website_id' => ['integer', 'exists:%system%.websites,id'],
-        'customer_id' => ['nullable','integer', 'exists:%system%.customers,id'],
+        'website_id' => ['integer', 'nullable', 'exists:%system%.websites,id'],
+        'customer_id' => ['nullable', 'integer', 'exists:%system%.customers,id'],
     ];
 }

--- a/tests/unit-tests/Repositories/HostnameRepositoryTest.php
+++ b/tests/unit-tests/Repositories/HostnameRepositoryTest.php
@@ -60,6 +60,49 @@ class HostnameRepositoryTest extends Test
         }
     }
 
+    /**
+     * @test
+     */
+    public function validation_under_maintenance()
+    {
+        try {
+            $this->hostname->under_maintenance_since = null;
+            $this->hostnames->update($this->hostname);
+            $this->assertNull($this->hostname->under_maintenance_since);
+        } catch (ModelValidationException $e) {
+            $this->fail("The validation should not fail, message: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function validation_redirect_to()
+    {
+        try {
+            $this->hostname->redirect_to = null;
+            $this->hostnames->update($this->hostname);
+            $this->assertNull($this->hostname->redirect_to);
+        } catch (ModelValidationException $e) {
+            $this->fail("The validation should not fail, message: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function validation_customer_id()
+    {
+        try {
+            $this->hostname->customer_id = null;
+            $this->hostnames->update($this->hostname);
+            $this->assertNull($this->hostname->customer_id);
+        } catch (ModelValidationException $e) {
+            $this->fail("The validation should not fail, message: {$e->getMessage()}");
+        }
+    }
+
+
     protected function duringSetUp(Application $app)
     {
         $this->setUpWebsites();

--- a/tests/unit-tests/Repositories/HostnameRepositoryTest.php
+++ b/tests/unit-tests/Repositories/HostnameRepositoryTest.php
@@ -102,6 +102,30 @@ class HostnameRepositoryTest extends Test
         }
     }
 
+    /**
+     * @test
+     */
+    public function validation_website_id()
+    {
+        try {
+            $this->hostname->website_id = null;
+            $this->hostnames->update($this->hostname);
+            $this->assertNull($this->hostname->website_id);
+        } catch (ModelValidationException $e) {
+            $this->fail("The validation should not fail, message: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function hostname_delete()
+    {
+        $this->hostnames->delete($this->hostname,false);
+        $this->assertFalse($this->hostname->exists);
+        $this->assertFalse($this->hostnames->query()->where('id', $this->hostname->id)->exists());
+    }
+
 
     protected function duringSetUp(Application $app)
     {


### PR DESCRIPTION
It should be possible to update a hostname and set `redirect_to`, `customer_id` and `under_maintenance_since` to `null`.