### PR TITLE
Fixes Maintenance-mode on the middleware

### DIFF
--- a/src/Events/Hostnames/NoneFound.php
+++ b/src/Events/Hostnames/NoneFound.php
@@ -14,9 +14,10 @@
 
 namespace Hyn\Tenancy\Events\Hostnames;
 
+use Hyn\Tenancy\Abstracts\AbstractEvent;
 use Illuminate\Http\Request;
 
-class NoneFound
+class NoneFound extends AbstractEvent
 {
     /**
      * @var Request

--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -44,7 +44,7 @@ class HostnameActions
      * @param CurrentHostname $hostname
      * @param Redirector $redirect
      */
-    public function __construct(CurrentHostname $hostname, Redirector $redirect)
+    public function __construct(CurrentHostname $hostname = null, Redirector $redirect)
     {
         $this->hostname = $hostname;
         $this->redirect = $redirect;
@@ -57,7 +57,7 @@ class HostnameActions
      */
     public function handle(Request $request, Closure $next)
     {
-        if ($this->hostname) {
+        if ($this->hostname != null) {
             if ($this->hostname->under_maintenance_since) {
                 return $this->maintenance($this->hostname);
             }
@@ -105,7 +105,6 @@ class HostnameActions
     protected function maintenance(Hostname $hostname)
     {
         $this->emitEvent(new UnderMaintenance($hostname));
-
         throw new MaintenanceModeException($hostname->under_maintenance_since->timestamp);
     }
 

--- a/src/Models/Hostname.php
+++ b/src/Models/Hostname.php
@@ -16,6 +16,7 @@ namespace Hyn\Tenancy\Models;
 
 use Carbon\Carbon;
 use Hyn\Tenancy\Abstracts\SystemModel;
+use Hyn\Tenancy\Contracts\CurrentHostname;
 
 /**
  * @property int $id
@@ -31,8 +32,10 @@ use Hyn\Tenancy\Abstracts\SystemModel;
  * @property int $customer_id
  * @property Customer $customer
  */
-class Hostname extends SystemModel
+class Hostname extends SystemModel implements CurrentHostname
 {
+    protected $dates = ['under_maintenance_since'];
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/tests/unit-tests/EnvironmentTest.php
+++ b/tests/unit-tests/EnvironmentTest.php
@@ -58,7 +58,8 @@ class EnvironmentTest extends Test
         $this->assertNull($identified);
 
         $this->hostname->save();
-        $this->app->make('config')->set('tenancy.hostname.default', $this->hostname->fqdn);
+        
+        config(['tenancy.hostname.default' => $this->hostname->fqdn]);
 
         $identified = $this->app->make(CurrentHostname::class);
 
@@ -73,6 +74,7 @@ class EnvironmentTest extends Test
     public function we_can_set_current_hostname_to_null_on_hostname_action_middleware()
     {
         $middleware = new HostnameActions(null, app()->make(Redirector::class));
+        
         $this->assertNotNull($middleware);
     }
 
@@ -80,11 +82,14 @@ class EnvironmentTest extends Test
     /**
      * @test
      */
-    public function middlware_fired_under_maintenance()
+    public function middleware_fired_under_maintenance()
     {
         $this->hostname->save();
-        $this->app->make('config')->set('tenancy.hostname.default', $this->hostname->fqdn);
+        
+        config(['tenancy.hostname.default' => $this->hostname->fqdn]);
+        
         $identified = $this->app->make(CurrentHostname::class);
+        
         $this->assertNotNull($identified);
 
         $now = Carbon::now();
@@ -98,6 +103,7 @@ class EnvironmentTest extends Test
             $a = $middleware->handle($request, function () {
                 return "ok";
             });
+            
             $this->fail('Middleware didn\'t fire maintenance exception');
         } catch (MaintenanceModeException $e) {
             $this->assertEquals($e->wentDownAt->timestamp, $now->timestamp);


### PR DESCRIPTION
This should fix the middleware.
As CurrentHostname is injected, it should be nullable. It could be applied to a route for a website which isn't identified. 

Added also some tests, plus, I made the `under_maintenance_since` a date in the `$dates` object.