### PR TITLE
Tenant specific migrations

### DIFF
--- a/src/Traits/MutatesMigrationCommands.php
+++ b/src/Traits/MutatesMigrationCommands.php
@@ -53,6 +53,7 @@ trait MutatesMigrationCommands
 
         $this->processHandle(function ($website) {
             $this->connection->set($website, $this->connection->migrationName());
+            $this->website = $website;
 
             parent::handle();
 
@@ -83,7 +84,7 @@ trait MutatesMigrationCommands
 
         // Tenant migrations path is configured.
         if ($path = config('tenancy.db.tenant-migrations-path')) {
-            return [$path];
+            return [$path, $path . '/' . $this->website->uuid];
         }
 
         return array_merge(


### PR DESCRIPTION
With this commit tenants can have migrations that are run only for them. If a tenant migration path is configured and there is a subdirectory with the website UUID in this path, the contained migrations will be run.