### PR TITLE
Forcing artisan calls.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -35,7 +35,7 @@
         <env name="DB_DATABASE" value="tenancy"/>
         <env name="TENANCY_SYSTEM_CONNECTION_NAME" value="mysql"/>
         <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="APP_ENV" value="testing"/>
+        <env name="APP_ENV" value="production"/>
         <env name="TENANCY_DEFAULT_HOSTNAME" value="local.testing"/>
     </php>
 </phpunit>

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -218,7 +218,8 @@ class Connection
 
         $options = [
             '--website_id' => [$website->id],
-            '-n' => 1
+            '-n' => 1,
+            '--force' => true
         ];
 
         if ($path) {
@@ -241,7 +242,8 @@ class Connection
 
         $options = [
             '--website_id' => [$website->id],
-            '-n' => 1
+            '-n' => 1,
+            '--force' => true
         ];
 
         if ($class) {

--- a/tests/traits/InteractsWithMigrations.php
+++ b/tests/traits/InteractsWithMigrations.php
@@ -28,7 +28,8 @@ trait InteractsWithMigrations
     {
         $code = $this->artisan("tenancy:$command", [
             '--realpath' => __DIR__ . '/../migrations',
-            '-n' => 1
+            '-n' => 1,
+            '--force' => true
         ]);
 
         $this->assertEquals(0, $code, "tenancy:$command didn't work out");
@@ -52,7 +53,8 @@ trait InteractsWithMigrations
     {
         $code = $this->artisan("tenancy:db:seed", [
             '--class' => SampleSeeder::class,
-            '-n' => 1
+            '-n' => 1,
+            '--force' => true
         ]);
 
         $this->assertEquals(0, $code, "tenancy:db:seed didn't work out");


### PR DESCRIPTION
When on production, this is needed, otherwise artisan will prompt an "Are you sure you want to run this on production" message.

I stumbled upon this when running it in production because of migrations not being run.