### PR TITLE
Disable SQL-user generation

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -185,6 +185,13 @@ return [
         'password-generator' => Hyn\Tenancy\Generators\Database\DefaultPasswordGenerator::class,
 
         /**
+         * Standard, tenancy will create a SQL-user for you and grant it access to a new created database.
+         * With this setting, you can turn that off. Please note that the user and password of the tenant-connection
+         * will be used to connect to the database if turned off.
+         */
+        'generate-sql-user' => true,
+
+        /**
          * The tenant migrations to be run during creation of a tenant. Specify a directory
          * to run the migrations from. If specified these migrations will be executed
          * whenever a new tenant is created.

--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -185,11 +185,14 @@ return [
         'password-generator' => Hyn\Tenancy\Generators\Database\DefaultPasswordGenerator::class,
 
         /**
-         * Standard, tenancy will create a SQL-user for you and grant it access to a new created database.
-         * With this setting, you can turn that off. Please note that the user and password of the tenant-connection
-         * will be used to connect to the database if turned off.
+         * By default tenancy will automatically create a database user with access
+         * to the tenant database. By disabling this feature you are able to
+         * implement your own user generation or - even if not recommended -
+         * re-use existing credentials.
+         *
+         * @info set to false to disable.
          */
-        'generate-sql-user' => true,
+        'generate-database-user' => true,
 
         /**
          * The tenant migrations to be run during creation of a tenant. Specify a directory

--- a/src/Contracts/Webserver/DatabaseGenerator.php
+++ b/src/Contracts/Webserver/DatabaseGenerator.php
@@ -21,7 +21,7 @@ use Hyn\Tenancy\Events\Websites\Updated;
 
 interface DatabaseGenerator
 {
-    public function created(Created $event, array $config, Connection $connection): bool;
+    public function created(Created $event, array $config, Connection $connection, bool $createUser): bool;
     public function updated(Updated $event, array $config, Connection $connection): bool;
     public function deleted(Deleted $event, array $config, Connection $connection): bool;
 }

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -275,7 +275,7 @@ class Connection
         switch ($mode) {
             case static::DIVISION_MODE_SEPARATE_DATABASE:
                 $clone['database'] = $website->uuid;
-                if (config('tenancy.db.generate-sql-user') === true) {
+                if (config('tenancy.db.generate-database-user') === true) {
                     $clone['username'] = $clone['database'];
                     $clone['password'] = $this->passwordGenerator->generate($website);
                 }

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -32,10 +32,10 @@ class Connection
 
     const DEFAULT_SYSTEM_NAME = 'system';
     const DEFAULT_TENANT_NAME = 'tenant';
-    
+
     /**
-    * @deprecated
-    */
+     * @deprecated
+     */
     const DEFAULT_MIGRATION_NAME = 'tenant-migration';
 
     const DIVISION_MODE_SEPARATE_DATABASE = 'database';
@@ -274,8 +274,11 @@ class Connection
 
         switch ($mode) {
             case static::DIVISION_MODE_SEPARATE_DATABASE:
-                $clone['username'] = $clone['database'] = $website->uuid;
-                $clone['password'] = $this->passwordGenerator->generate($website);
+                $clone['database'] = $website->uuid;
+                if (config('tenancy.db.generate-sql-user') === true) {
+                    $clone['username'] = $clone['database'];
+                    $clone['password'] = $this->passwordGenerator->generate($website);
+                }
                 break;
             case static::DIVISION_MODE_SEPARATE_PREFIX:
                 $clone['prefix'] = sprintf('%d_', $website->id);

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -78,6 +78,7 @@ class DatabaseGenerator
     /**
      * @param Events\Websites\Created $event
      * @throws GeneratorFailedException
+     * @throws \Hyn\Tenancy\Exceptions\ConnectionException
      */
     public function created(Events\Websites\Created $event)
     {
@@ -97,7 +98,8 @@ class DatabaseGenerator
             new Events\Database\Creating($config, $event->website)
         );
 
-        if (!$this->driver($config)->created($event, $config, $this->connection)) {
+        if (!$this->driver($config)->created($event, $config, $this->connection,
+            config('tenancy.db.generate-sql-user'))) {
             throw new GeneratorFailedException("Could not generate database {$config['database']}, one of the statements failed.");
         }
 
@@ -115,7 +117,7 @@ class DatabaseGenerator
     {
         $host = Arr::get($config, 'host');
 
-        if (! in_array($host, ['localhost', '127.0.0.1', '192.168.0.1'])) {
+        if (!in_array($host, ['localhost', '127.0.0.1', '192.168.0.1'])) {
             $config['host'] = '%';
         }
     }
@@ -123,6 +125,7 @@ class DatabaseGenerator
     /**
      * @param Events\Websites\Deleted $event
      * @throws GeneratorFailedException
+     * @throws \Hyn\Tenancy\Exceptions\ConnectionException
      */
     public function deleted(Events\Websites\Deleted $event)
     {
@@ -152,6 +155,7 @@ class DatabaseGenerator
     /**
      * @param Events\Websites\Updated $event
      * @throws GeneratorFailedException
+     * @throws \Hyn\Tenancy\Exceptions\ConnectionException
      */
     public function updated(Events\Websites\Updated $event)
     {

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -99,7 +99,7 @@ class DatabaseGenerator
         );
 
         if (!$this->driver($config)->created($event, $config, $this->connection,
-            config('tenancy.db.generate-sql-user'))) {
+            config('tenancy.db.generate-database-user'))) {
             throw new GeneratorFailedException("Could not generate database {$config['database']}, one of the statements failed.");
         }
 

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -59,7 +59,7 @@ class MariaDB implements DatabaseGenerator
     {
         $uuid = Arr::get($event->dirty, 'uuid');
 
-        $this->created(new Created($event->website), $config, $connection, config('tenancy.db.generate-sql-user'));
+        $this->created(new Created($event->website), $config, $connection, config('tenancy.db.generate-database-user'));
 
 //        if (!$connection->system()->statement("RENAME TABLE `$uuid`.`table` TO `{$config['database']}`.`table`")) {
 //            throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -29,15 +29,18 @@ class MariaDB implements DatabaseGenerator
      * @param Created $event
      * @param array $config
      * @param Connection $connection
+     * @param bool $createUser
      * @return bool
+     * @throws \Exception
+     * @throws \Throwable
      */
-    public function created(Created $event, array $config, Connection $connection): bool
+    public function created(Created $event, array $config, Connection $connection, bool $createUser): bool
     {
         $create = function ($connection) use ($config) {
             return $connection->statement("CREATE DATABASE `{$config['database']}`");
         };
-        $grant = function ($connection) use ($config) {
-            return $connection->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'");
+        $grant = function ($connection) use ($config, $createUser) {
+            return $createUser ? $connection->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'") : true;
         };
 
         return $connection->system()->transaction(function (IlluminateConnection $connection) use ($create, $grant) {
@@ -56,7 +59,7 @@ class MariaDB implements DatabaseGenerator
     {
         $uuid = Arr::get($event->dirty, 'uuid');
 
-        $this->created(new Created($event->website), $config, $connection);
+        $this->created(new Created($event->website), $config, $connection, config('tenancy.db.generate-sql-user'));
 
 //        if (!$connection->system()->statement("RENAME TABLE `$uuid`.`table` TO `{$config['database']}`.`table`")) {
 //            throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");

--- a/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
@@ -28,14 +28,15 @@ class PostgreSQL implements DatabaseGenerator
      * @param Created $event
      * @param array $config
      * @param Connection $connection
+     * @param bool $createUser
      * @return bool
      */
-    public function created(Created $event, array $config, Connection $connection): bool
+    public function created(Created $event, array $config, Connection $connection, bool $createUser): bool
     {
         $connection = $connection->system();
 
-        $user = function () use ($connection, $config) {
-            return $connection->statement("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'");
+        $user = function () use ($connection, $config, $createUser) {
+            return $createUser ? $connection->statement("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'") : true;
         };
         $create = function () use ($connection, $config) {
             return $connection->statement("CREATE DATABASE \"{$config['database']}\" WITH OWNER=\"{$config['username']}\"");

--- a/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
+++ b/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
@@ -28,11 +28,12 @@ class WebsiteRepositoryTest extends Test
     public function __construct()
     {
         parent::__construct();
+        
         $db = getenv('DB_CONNECTION');
+        $this->tableForUsers = 'pg_catalog.pg_user';
+
         if (!$db || $db == 'mysql') {
             $this->tableForUsers = 'mysql.user';
-        } else {
-            $this->tableForUsers = 'pg_catalog.pg_user';
         }
     }
 

--- a/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
+++ b/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
@@ -20,6 +20,23 @@ class WebsiteRepositoryTest extends Test
 {
 
     /**
+     * The table for the users.
+     * @var null|string
+     */
+    private $tableForUsers = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $db = getenv('DB_CONNECTION');
+        if (!$db) {
+            $this->tableForUsers = 'mysql.user';
+        } else {
+            $this->tableForUsers = 'pg_catalog.pg_user';
+        }
+    }
+
+    /**
      * @test
      */
     public function creates_website()
@@ -27,6 +44,32 @@ class WebsiteRepositoryTest extends Test
         $this->websites->create($this->website);
 
         $this->assertTrue($this->website->exists);
+    }
+
+    /**
+     * @test
+     */
+    public function create_website_with_sql_user()
+    {
+        $amount_of_sql_users_before = $this->connection->system()->table($this->tableForUsers)->count();
+        $this->websites->create($this->website);
+        $this->assertTrue($this->website->exists);
+        $amount_of_sql_users_after = $this->connection->system()->table($this->tableForUsers)->count();
+        $this->assertEquals($amount_of_sql_users_before + 1, $amount_of_sql_users_after,
+            'An unexpected amount of SQL-users has been created.');
+    }
+
+    /**
+     * @test
+     */
+    public function create_website_without_sql_user()
+    {
+        config(['tenancy.db.generate-sql-user' => false]);
+        $amount_of_sql_users_before = $this->connection->system()->table($this->tableForUsers)->count();
+        $this->websites->create($this->website);
+        $this->assertTrue($this->website->exists);
+        $amount_of_sql_users_after = $this->connection->system()->table($this->tableForUsers)->count();
+        $this->assertEquals($amount_of_sql_users_before, $amount_of_sql_users_after, 'A SQL-user has been created.');
     }
 
     /**

--- a/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
+++ b/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
@@ -65,7 +65,7 @@ class WebsiteRepositoryTest extends Test
      */
     public function create_website_without_sql_user()
     {
-        config(['tenancy.db.generate-sql-user' => false]);
+        config(['tenancy.db.generate-database-user' => false]);
         $amount_of_sql_users_before = $this->connection->system()->table($this->tableForUsers)->count();
         $this->websites->create($this->website);
         $this->assertTrue($this->website->exists);

--- a/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
+++ b/tests/unit-tests/Repositories/WebsiteRepositoryTest.php
@@ -29,7 +29,7 @@ class WebsiteRepositoryTest extends Test
     {
         parent::__construct();
         $db = getenv('DB_CONNECTION');
-        if (!$db) {
+        if (!$db || $db == 'mysql') {
             $this->tableForUsers = 'mysql.user';
         } else {
             $this->tableForUsers = 'pg_catalog.pg_user';


### PR DESCRIPTION
Since I do not  want to create a SQL-user, I decided to create a PR that disables the SQL-user generation.

If a user of the package disables the generation of the SQL-user, he/she needs to make sure that the sql-user on the 'tenant'-connection can access the tenant database.

What are your thoughts?