### PR TITLE
Invalid Hostname detection broken

### DIFF
--- a/tests/unit-tests/EnvironmentTest.php
+++ b/tests/unit-tests/EnvironmentTest.php
@@ -73,7 +73,7 @@ class EnvironmentTest extends Test
      */
     public function we_can_set_current_hostname_to_null_on_hostname_action_middleware()
     {
-        $middleware = new HostnameActions(null, app()->make(Redirector::class));
+        $middleware = new HostnameActions(app()->make(Redirector::class));
 
         $this->assertNotNull($middleware);
     }
@@ -97,7 +97,7 @@ class EnvironmentTest extends Test
         $identified->save();
 
         $request = new Request();
-        $middleware = new HostnameActions($identified, app()->make(Redirector::class));
+        $middleware = new HostnameActions(app()->make(Redirector::class));
 
         try {
             $a = $middleware->handle($request, function () {


### PR DESCRIPTION
**Background:**
I was having significant difficulty getting my site to 404 on invalid hostnames, and found a few issues like missing config keys and other easily resolved issues.  Also found that the `HostnameActions::abort()` method was never firing.  After a little digging, I discovered the issue.

**Problem:**
If Eager (early) Identification is enabled, it will grab the `Environment`, which (may) auto-identify the current hostname.  The `$hostname` passed into the `HostnameActions` constructor is a blank object, since it's not tied to anything.  What we REALLY need here is `CurrentHostname`, but we can't DI that there because it returns an implementation of `Hostname`, not of `CurrentHostname`.

**Solution:**
I removed `$this->hostname` since it was passed directly into all other methods anyway, and made changed it to use `CurrentHostname` instead.  This