### PR TITLE
Tenant language improvements and fixes

### DIFF
--- a/src/Listeners/Filesystem/LoadsTranslations.php
+++ b/src/Listeners/Filesystem/LoadsTranslations.php
@@ -17,6 +17,7 @@ namespace Hyn\Tenancy\Listeners\Filesystem;
 use Hyn\Tenancy\Abstracts\AbstractTenantDirectoryListener;
 use Hyn\Tenancy\Abstracts\HostnameEvent;
 use Hyn\Tenancy\Exceptions\FilesystemException;
+use Hyn\Tenancy\Listeners\Filesystem\MultiFileLoader;
 use Illuminate\Translation\FileLoader;
 use Illuminate\Translation\Translator;
 
@@ -51,13 +52,15 @@ class LoadsTranslations extends AbstractTenantDirectoryListener
     protected function readLanguageFiles(string $path)
     {
         if ($this->config->get('tenancy.folders.trans.override-global')) {
-            app()->singleton('translation.loader', function ($app) use ($path) {
-                return new FileLoader($app['files'], $path);
-            });
-            app()->singleton('translator', function ($app) {
-                $translator = new Translator($app['translation.loader'], $app['config']['app.locale']);
-                $translator->setFallback($app['config']['app.fallback_locale']);
-                return $translator;
+            app()->extend('translation.loader', function ($loader) use ($path) {
+                if ($loader instanceof MultiFileLoader) {
+                    return $loader->addLoader(new FileLoader(app()->make('files'), $path));
+                }
+
+                $multiLoader = new LanguageFileLoader(app()->make('files'), $path);
+                $multiLoader->addLoader($loader);
+                $multiLoader->addLoader(new FileLoader(app()->make('files'), $path));
+                return $multiLoader;
             });
         } elseif ($namespace = $this->config->get('tenancy.folders.trans.namespace')) {
             app('translator')->addNamespace($namespace, $path);

--- a/src/Listeners/Filesystem/MultiFileLoader.php
+++ b/src/Listeners/Filesystem/MultiFileLoader.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Listeners\Filesystem;
+
+use Illuminate\Translation\FileLoader;
+use Illuminate\Contracts\Translation\Loader;
+use Illuminate\Filesystem\Filesystem;
+
+class MultiFileLoader extends FileLoader
+{
+    /**
+     * Create a new file loader instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  string  $path
+     * @return void
+     */
+    public function __construct(Filesystem $files, $path)
+    {
+        parent::__construct($files, $path);
+        $this->addLoader(new FileLoader(app()->make('files'), $path));
+    }
+
+    /**
+     * @var \Illuminate\Translation\FileLoader
+     */
+    protected $fileLoaders = [];
+
+    public function addLoader(\Illuminate\Translation\FileLoader $loader)
+    {
+        $this->fileLoaders[] = $loader;
+        return $this;
+    }
+
+    /**
+     * Load the messages for the given locale.
+     *
+     * @param  string  $locale
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return array
+     */
+    public function load($locale, $group, $namespace = null)
+    {
+        $results = [];
+        foreach ($this->fileLoaders as $loader) {
+            $results = array_merge($results, $loader->load($locale, $group, $namespace));
+        }
+
+        return $results;
+    }
+}


### PR DESCRIPTION
Fixed a bug where language files in a tenants directory were not being loaded if language files already exist in the global project.

Changed behaviour of tenant language files to merge with, rather than override entirely, global language files.