### PR TITLE
Use `exists()` method instead of `exists` property on repositories

### DIFF
--- a/src/Repositories/CustomerRepository.php
+++ b/src/Repositories/CustomerRepository.php
@@ -52,7 +52,7 @@ class CustomerRepository implements Contract
      */
     public function create(Customer &$customer): Customer
     {
-        if ($customer->exists) {
+        if ($customer->exists()) {
             return $this->update($customer);
         }
 
@@ -75,7 +75,7 @@ class CustomerRepository implements Contract
      */
     public function update(Customer &$customer): Customer
     {
-        if (!$customer->exists) {
+        if (!$customer->exists()) {
             return $this->create($customer);
         }
 

--- a/src/Repositories/HostnameRepository.php
+++ b/src/Repositories/HostnameRepository.php
@@ -84,7 +84,7 @@ class HostnameRepository implements Contract
      */
     public function create(Hostname &$hostname): Hostname
     {
-        if ($hostname->exists) {
+        if ($hostname->exists()) {
             return $this->update($hostname);
         }
 
@@ -109,7 +109,7 @@ class HostnameRepository implements Contract
      */
     public function update(Hostname &$hostname): Hostname
     {
-        if (!$hostname->exists) {
+        if (!$hostname->exists()) {
             return $this->create($hostname);
         }
 

--- a/src/Repositories/WebsiteRepository.php
+++ b/src/Repositories/WebsiteRepository.php
@@ -77,7 +77,7 @@ class WebsiteRepository implements Contract
      */
     public function create(Website &$website): Website
     {
-        if ($website->exists) {
+        if ($website->exists()) {
             return $this->update($website);
         }
 
@@ -104,7 +104,7 @@ class WebsiteRepository implements Contract
      */
     public function update(Website &$website): Website
     {
-        if (!$website->exists) {
+        if (!$website->exists()) {
             return $this->create($website);
         }
 


### PR DESCRIPTION
The create() and update() methods on the repositories don't seem to be behaving as they should.

I'm not positive, but shouldn't these be `exists()` methods instead of properties? Changing them to methods seemed to fix the problem I have was having when creating things that already exist.