### PR TITLE
Fix for CurrentHostname throwing error

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -38,7 +38,6 @@ class Environment
         $this->app = $app;
 
         if ($this->installed() && config('tenancy.hostname.auto-identification')) {
-            $this->identifyHostname();
             // Identifies the current hostname, sets the binding using the native resolving strategy.
             $this->app->make(CurrentHostname::class);
         }
@@ -50,18 +49,6 @@ class Environment
     public function installed(): bool
     {
         return file_exists(base_path('tenancy.json'));
-    }
-
-    /**
-     * Auto identification of the tenant hostname to use.
-     */
-    public function identifyHostname()
-    {
-        $this->app->singleton(CurrentHostname::class, function () {
-            $hostname = $this->dispatch(new HostnameIdentification);
-
-            return $hostname;
-        });
     }
 
     /**

--- a/src/Providers/TenancyProvider.php
+++ b/src/Providers/TenancyProvider.php
@@ -92,6 +92,7 @@ class TenancyProvider extends ServiceProvider
         $this->app->register(Providers\UuidProvider::class);
         $this->app->register(Providers\BusProvider::class);
         $this->app->register(Providers\FilesystemProvider::class);
+        $this->app->register(Providers\HostnameProvider::class);
 
         // Register last.
         $this->app->register(Providers\EventProvider::class);

--- a/src/Providers/Tenants/HostnameProvider.php
+++ b/src/Providers/Tenants/HostnameProvider.php
@@ -1,0 +1,26 @@
+<?php
+namespace Hyn\Tenancy\Providers\Tenants;
+
+use Hyn\Tenancy\Contracts\CurrentHostname;
+use Hyn\Tenancy\Jobs\HostnameIdentification;
+use Hyn\Tenancy\Traits\DispatchesJobs;
+use Illuminate\Support\ServiceProvider;
+
+class HostnameProvider extends ServiceProvider
+{
+    use DispatchesJobs;
+
+    public function provides()
+    {
+        return [CurrentHostname::class];
+    }
+
+    public function register()
+    {
+        $this->app->singleton(CurrentHostname::class, function () {
+            $hostname = $this->dispatch(new HostnameIdentification);
+
+            return $hostname;
+        });
+    }
+}

--- a/src/Providers/Tenants/HostnameProvider.php
+++ b/src/Providers/Tenants/HostnameProvider.php
@@ -1,4 +1,17 @@
 <?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
 namespace Hyn\Tenancy\Providers\Tenants;
 
 use Hyn\Tenancy\Contracts\CurrentHostname;


### PR DESCRIPTION
Related to/Partial fix for #357 and partially caused by [my fix](https://github.com/hyn/multi-tenant/pull/346/files#diff-0bfc9e44dd1452c380759a4f4e98ebe5R54) for #346 

Moved definition of CurrentHostname singleton to it's own ServiceProvider so requests for it don't trigger "cannot be instantiated" errors.  Defining singleton does not run it's closure, so no need to check for the `auto-identification` config.