### PR TITLE
Fix tenancy:migrate:refresh bug - Issue#385

### DIFF
--- a/src/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Database/Console/Migrations/RefreshCommand.php
@@ -20,4 +20,32 @@ use Illuminate\Database\Console\Migrations\RefreshCommand as BaseCommand;
 class RefreshCommand extends BaseCommand
 {
     use MutatesMigrationCommands;
+
+    public function handle()
+    {
+        if (!$this->confirmToProceed()) {
+            return;
+        }
+
+        $this->input->setOption('force', true);
+        $this->input->setOption('database', $this->connection->tenantName());
+        $this->input->setOption('path', $this->getRelativeMigrationsPaths());
+
+        $this->processHandle(function ($website) {
+            $this->connection->set($website);
+            parent::handle();
+            $this->connection->purge();
+        });
+    }
+
+    public function getRelativeMigrationsPaths()
+    {
+        $paths = $this->getMigrationPaths();
+        $relativePaths = [];
+        foreach ($paths as $path) {
+            $relativePaths[] = str_replace(base_path(), '', $path);
+        }
+
+        return $relativePaths;
+    }
 }


### PR DESCRIPTION
This PR solve the [issue#385](https://github.com/hyn/multi-tenant/issues/385).

I rewrote just the handle method from the trait **MutatesMigrationCommands**, adding the path option. This way we're still running the **migrate:reset** and **migrate** commands, but now looking in the right paths.
