### PR TITLE
Added onHostname method to TenantAwareJob.

### DIFF
--- a/src/Queue/TenantAwareJob.php
+++ b/src/Queue/TenantAwareJob.php
@@ -37,7 +37,7 @@ trait TenantAwareJob
 
         $hostname = $environment->hostname();
 
-        if (isset($hostname) && !isset($this->hostname_id)) {
+        if ($hostname && !$this->hostname_id) {
             $this->hostname_id = $hostname->id;
         }
 
@@ -62,7 +62,8 @@ trait TenantAwareJob
     /**
      * Manually override the hostname to be used.
      *
-     * @param mixed $hostname
+     * @param Hostname|int $hostname
+     * @return $this
      */
     public function onHostname($hostname)
     {

--- a/src/Queue/TenantAwareJob.php
+++ b/src/Queue/TenantAwareJob.php
@@ -35,7 +35,9 @@ trait TenantAwareJob
         /** @var Environment $environment */
         $environment = app(Environment::class);
 
-        if ($hostname = $environment->hostname()) {
+        $hostname = $environment->hostname();
+
+        if (isset($hostname) && !isset($this->hostname_id)) {
             $this->hostname_id = $hostname->id;
         }
 
@@ -55,5 +57,17 @@ trait TenantAwareJob
         }
 
         $this->serializedWakeup();
+    }
+
+    /**
+     * Manually override the hostname to be used.
+     *
+     * @param mixed $hostname
+     */
+    public function onHostname($hostname)
+    {
+        $this->hostname_id = $hostname instanceof Hostname ? $hostname->id : $hostname;
+
+        return $this;
     }
 }

--- a/tests/unit-tests/Queue/TenantAwareJobTest.php
+++ b/tests/unit-tests/Queue/TenantAwareJobTest.php
@@ -69,9 +69,9 @@ class TenantAwareJobTest extends Test
     {
         $this->app->make(CurrentHostname::class);
 
-        $manualHostname = $this->getReplicatedHostname();
+        $hostname = $this->getReplicatedHostname();
 
-        $job = (new JobExtend())->onHostname($manualHostname);
+        $job = (new JobExtend())->onHostname($hostname);
 
         $attributes = serialize($job);
 
@@ -82,6 +82,6 @@ class TenantAwareJobTest extends Test
 
         $restored = $this->environment->hostname();
 
-        $this->assertEquals($manualHostname->fqdn, $restored->fqdn);
+        $this->assertEquals($hostname->fqdn, $restored->fqdn);
     }
 }

--- a/tests/unit-tests/Queue/TenantAwareJobTest.php
+++ b/tests/unit-tests/Queue/TenantAwareJobTest.php
@@ -38,7 +38,7 @@ class TenantAwareJobTest extends Test
     /**
      * @test
      */
-    public function serializes_tenant()
+    public function serializes_current_tenant()
     {
         $this->app->make(CurrentHostname::class);
 
@@ -60,5 +60,28 @@ class TenantAwareJobTest extends Test
         $restored = $this->environment->hostname();
 
         $this->assertNotEquals($identified->fqdn, $restored->fqdn);
+    }
+
+    /**
+     * @test
+     */
+    public function serializes_manual_tenant()
+    {
+        $this->app->make(CurrentHostname::class);
+
+        $manualHostname = $this->getReplicatedHostname();
+
+        $job = (new JobExtend())->onHostname($manualHostname);
+
+        $attributes = serialize($job);
+
+        /** @var JobExtend $job */
+        $job = unserialize($attributes);
+
+        $this->assertInstanceOf(JobExtend::class, $job);
+
+        $restored = $this->environment->hostname();
+
+        $this->assertEquals($manualHostname->fqdn, $restored->fqdn);
     }
 }


### PR DESCRIPTION
This method allows for the tenant the job is aware of to be manually overridden or set without an environment being set.

This is also useful for when jobs are going to be dispatched across many tenants. E.g. From a cron job can now easily dispatch a job on many tenants without having to set the environment.