### PR TITLE
Use trailing slash for Apache alias target

### DIFF
--- a/assets/generators/webserver/apache/blocks/server.blade.php
+++ b/assets/generators/webserver/apache/blocks/server.blade.php
@@ -8,7 +8,7 @@
 
     @if($media)
         # media directory
-        alias "/media/" "{{ $media . DIRECTORY_SEPARATOR }}"
+        alias "/media/" "{{ $media }}/"
     @endif
 
     # allow cross domain loading of resources

--- a/assets/generators/webserver/apache/blocks/server.blade.php
+++ b/assets/generators/webserver/apache/blocks/server.blade.php
@@ -8,7 +8,7 @@
 
     @if($media)
         # media directory
-        alias "/media/" "{{ $media }}"
+        alias "/media/" "{{ $media . DIRECTORY_SEPARATOR }}"
     @endif
 
     # allow cross domain loading of resources


### PR DESCRIPTION
Without a trailing slash all files in the aliased folder seem to return a 404 error. Adding the slash fixes the issue.

Not sure if the slash should be added in ApacheGenerator or in the template. Given paths are usually passed without a trailing slash in Laravel I think it makes sense to append it at the last moment.

This PR was tested on Ubuntu 16.04, Apache/2.4.18. I wonder why nobody else hit this issue ? Was nobody using the alias feature or does it work without the trailing slash on other systems ?