### PR TITLE
support for multi dbs

### DIFF
--- a/assets/migrations/2018_04_06_000001_tenancy_websites_needs_db_host.php
+++ b/assets/migrations/2018_04_06_000001_tenancy_websites_needs_db_host.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+use Hyn\Tenancy\Abstracts\AbstractMigration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class TenancyWebsitesNeedsDbHost extends AbstractMigration
+{
+    protected $system = true;
+
+    public function up()
+    {
+        Schema::table('websites', function (Blueprint $table) {
+            $table->string('managed_by_database_connection')
+                ->nullable()
+                ->comment('References the database connection key in your database.php');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('websites', function (Blueprint $table) {
+            $table->dropColumn('managed_by_database_connection');
+        });
+    }
+}

--- a/src/Contracts/Website.php
+++ b/src/Contracts/Website.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property Carbon $updated_at
  * @property Carbon $deleted_at
  * @property int $customer_id
+ * @property string $managed_by_database_connection
  * @property Customer $customer
  * @property Hostname[] $hostnames
  */

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -252,7 +252,7 @@ class Connection
     {
         $clone = config(sprintf(
             'database.connections.%s',
-            $this->systemName()
+            $website->managed_by_database_connection ?? $this->systemName()
         ));
 
         $mode = config('tenancy.db.tenant-division-mode');

--- a/src/Listeners/Database/FillsConnectionUsed.php
+++ b/src/Listeners/Database/FillsConnectionUsed.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Hyn\Tenancy\Listeners\Database;
+
+use Hyn\Tenancy\Database\Connection;
+use Hyn\Tenancy\Events\Websites\Created;
+use Hyn\Tenancy\Events\Websites\Updated;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class FillsConnectionUsed
+{
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen([Created::class, Updated::class], [$this, 'set']);
+    }
+
+    public function set($event)
+    {
+        if (!$event->website->managed_by_database_connection) {
+            $event->website->managed_by_database_connection = $this->connection->systemName();
+        }
+    }
+}

--- a/src/Listeners/Database/FillsConnectionUsed.php
+++ b/src/Listeners/Database/FillsConnectionUsed.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
 namespace Hyn\Tenancy\Listeners\Database;
 
 use Hyn\Tenancy\Database\Connection;

--- a/src/Models/Website.php
+++ b/src/Models/Website.php
@@ -17,6 +17,7 @@ namespace Hyn\Tenancy\Models;
 use Carbon\Carbon;
 use Hyn\Tenancy\Abstracts\SystemModel;
 use Hyn\Tenancy\Contracts\Website as WebsiteContract;
+use Hyn\Tenancy\Database\Connection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -27,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property Carbon $updated_at
  * @property Carbon $deleted_at
  * @property int $customer_id
+ * @property string $managed_by_database_connection
  * @property Customer $customer
  * @property Hostname[] $hostnames
  */
@@ -40,5 +42,10 @@ class Website extends SystemModel implements WebsiteContract
     public function hostnames(): HasMany
     {
         return $this->hasMany(config('tenancy.models.hostname'));
+    }
+
+    public function getConnectionName()
+    {
+        return $this->managed_by_database_connection ?? app(Connection::class)->systemName();
     }
 }

--- a/src/Providers/Tenants/EventProvider.php
+++ b/src/Providers/Tenants/EventProvider.php
@@ -33,6 +33,8 @@ class EventProvider extends ServiceProvider
         Listeners\Database\MigratesTenants::class,
         // Runs the seeds after the first migration
         Listeners\Database\SeedsTenants::class,
+        // Sets the connection used to manage tenant.
+        Listeners\Database\FillsConnectionUsed::class,
         // Manages the directories for the tenants.
         Generators\Filesystem\DirectoryGenerator::class,
         // Sets the uuid value on a website based on tenancy configuration.


### PR DESCRIPTION
Currently we assume databases are created based off of the current system connection. Whenever you plan on moving a tenant to another server we need to allow the database creation there with full support to manage the database; including deletion and updating.

In order to do so we will be storing a column on the Website table which will relate to a database connection configured in `app/database.php`.

/cc @julesbloemen