### PR TITLE
Moving CurrentHostname resolution to it's own ServiceProvider.

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -41,8 +41,6 @@ class Environment
         $this->app = $app;
 
         if ($this->installed() && config('tenancy.hostname.auto-identification')) {
-            // Resolves current hostname, even if set in env variable.
-            $this->identifyHostname();
             // Identifies the current hostname, sets the binding using the native resolving strategy.
             $this->app->make(CurrentHostname::class);
         }
@@ -61,15 +59,6 @@ class Environment
         } catch (QueryException $e) {
             return false;
         }
-    }
-
-    public function identifyHostname()
-    {
-        $this->app->singleton(CurrentHostname::class, function () {
-            $hostname = $this->dispatch(new HostnameIdentification);
-
-            return $hostname;
-        });
     }
 
     /**

--- a/src/Providers/TenancyProvider.php
+++ b/src/Providers/TenancyProvider.php
@@ -92,6 +92,7 @@ class TenancyProvider extends ServiceProvider
         $this->app->register(Providers\UuidProvider::class);
         $this->app->register(Providers\BusProvider::class);
         $this->app->register(Providers\FilesystemProvider::class);
+        $this->app->register(Providers\HostnameProvider::class);
 
         // Register last.
         $this->app->register(Providers\EventProvider::class);

--- a/src/Providers/Tenants/HostnameProvider.php
+++ b/src/Providers/Tenants/HostnameProvider.php
@@ -1,0 +1,28 @@
+<?php
+namespace Hyn\Tenancy\Providers\Tenants;
+
+use Hyn\Tenancy\Contracts\CurrentHostname;
+use Hyn\Tenancy\Jobs\HostnameIdentification;
+use Hyn\Tenancy\Traits\DispatchesJobs;
+use Illuminate\Support\ServiceProvider;
+
+class HostnameProvider extends ServiceProvider
+{
+    use DispatchesJobs;
+
+    public $defer = true;
+
+    public function provides()
+    {
+        return [CurrentHostname::class];
+    }
+
+    public function register()
+    {
+        $this->app->singleton(CurrentHostname::class, function () {
+            $hostname = $this->dispatch(new HostnameIdentification());
+
+            return $hostname;
+        });
+    }
+}


### PR DESCRIPTION
This is in relation to a conversation that occurred on Discord.

Currently, there are instances where calling `app(CurrentHostname::class)` will fail.

This pull request moves the hostname resolution logic to it's own ServiceProvider, which further decouples it from the rest of the code.  This means you are no longer required to resolve `Environment` first.