### PR TITLE
Fix HostnameAction Middleware (#489)

### DIFF
--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -51,7 +51,7 @@ class HostnameActions
      */
     public function handle(Request $request, Closure $next)
     {
-        $hostname = app(CurrentHostname::class);
+        $hostname = config('tenancy.hostname.auto-identification') ? app(CurrentHostname::class) : null;
 
         if ($hostname != null) {
             $this->setAppUrl($request, $hostname);

--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -51,8 +51,8 @@ class HostnameActions
      */
     public function handle(Request $request, Closure $next)
     {
-        $hostname = config('tenancy.hostname.auto-identification') 
-            ? app(CurrentHostname::class) 
+        $hostname = config('tenancy.hostname.auto-identification')
+            ? app(CurrentHostname::class)
             : null;
 
         if ($hostname != null) {

--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -51,7 +51,9 @@ class HostnameActions
      */
     public function handle(Request $request, Closure $next)
     {
-        $hostname = config('tenancy.hostname.auto-identification') ? app(CurrentHostname::class) : null;
+        $hostname = config('tenancy.hostname.auto-identification') 
+            ? app(CurrentHostname::class) 
+            : null;
 
         if ($hostname != null) {
             $this->setAppUrl($request, $hostname);

--- a/tests/unit-tests/Middleware/HostnameActionsTest.php
+++ b/tests/unit-tests/Middleware/HostnameActionsTest.php
@@ -14,6 +14,7 @@
 
 namespace Hyn\Tenancy\Tests\Middleware;
 
+use Exception;
 use Hyn\Tenancy\Contracts\CurrentHostname;
 use Hyn\Tenancy\Contracts\Hostname;
 use Hyn\Tenancy\Middleware\HostnameActions;
@@ -23,6 +24,7 @@ use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\Carbon;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class HostnameActionsTest extends Test
 {
@@ -87,6 +89,27 @@ class HostnameActionsTest extends Test
         $this->assertNotNull($middleware);
     }
 
+    /**
+     * @test
+     */
+    public function auto_identification_false()
+    {
+        config(['tenancy.hostname.auto-identification' => false]);
+
+        try {
+            $middleware = new HostnameActions(app()->make(Redirector::class));
+
+            $request = new Request();
+
+            $middleware->handle($request, function () {
+                return static::RESPONSE;
+            });
+
+        } catch (Exception $e) {
+            $this->assertInstanceOf(NotFoundHttpException::class, $e);
+        }
+    }
+
     protected function middleware(Hostname $set = null)
     {
         config(['tenancy.hostname.default' => optional($set)->fqdn]);
@@ -106,7 +129,6 @@ class HostnameActionsTest extends Test
             return static::RESPONSE;
         });
     }
-
 
     protected function duringSetUp(Application $app)
     {

--- a/tests/unit-tests/Middleware/HostnameActionsTest.php
+++ b/tests/unit-tests/Middleware/HostnameActionsTest.php
@@ -104,7 +104,6 @@ class HostnameActionsTest extends Test
             $middleware->handle($request, function () {
                 return static::RESPONSE;
             });
-
         } catch (Exception $e) {
             $this->assertInstanceOf(NotFoundHttpException::class, $e);
         }


### PR DESCRIPTION
Fixes #489 

Test
```
☁  multi-tenant [bsk/489-fix-hostname-action-middleware] ⚡  LIMIT_UUID_LENGTH_32=1 vendor/bin/phpunit

PHPUnit 7.2.3 by Sebastian Bergmann and contributors.

...............................S................................. 65 / 78 ( 83%)
.......SSSS..                                                     78 / 78 (100%)

Time: 11.29 seconds, Memory: 36.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 78, Assertions: 202, Skipped: 5.
```