### PR TITLE
Fix HostnameAction Middleware (#489)

### DIFF
--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -51,7 +51,9 @@ class HostnameActions
      */
     public function handle(Request $request, Closure $next)
     {
-        $hostname = app(CurrentHostname::class);
+        if (config('tenancy.hostname.auto-identification')) {
+            $hostname = app(CurrentHostname::class);
+        }
 
         if ($hostname != null) {
             $this->setAppUrl($request, $hostname);


### PR DESCRIPTION
Fixes #489 

Test
```
☁  multi-tenant [bsk/489-fix-hostnames-middleware-5.1] ⚡  LIMIT_UUID_LENGTH_32=1 vendor/bin/phpunit

PHPUnit 7.2.3 by Sebastian Bergmann and contributors.

...............................S................................. 65 / 80 ( 81%)
.........SSSS..                                                   80 / 80 (100%)

Time: 14.85 seconds, Memory: 38.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 80, Assertions: 205, Skipped: 5.
```