### PR TITLE
Change reload command for nginx

### DIFF
--- a/assets/configs/webserver.php
+++ b/assets/configs/webserver.php
@@ -167,7 +167,7 @@ return [
                 /**
                  * Action to run to reload the nginx service.
                  */
-                'reload' => 'systemctl restart nginx'
+                'reload' => 'systemctl reload nginx'
             ]
         ]
     ]


### PR DESCRIPTION
change `restart` to `reload` in order to avoid nginx being rebooted and therefore down time.