### PR TITLE
patched the fresh command

### DIFF
--- a/src/Database/Console/Migrations/FreshCommand.php
+++ b/src/Database/Console/Migrations/FreshCommand.php
@@ -2,8 +2,7 @@
 
 namespace Hyn\Tenancy\Database\Console\Migrations;
 
-use http\Exception\RuntimeException;
-use Hyn\Tenancy\Exceptions\ConnectionException;
+use Hyn\Tenancy\Models\Website;
 use Hyn\Tenancy\Traits\MutatesMigrationCommands;
 use Illuminate\Database\Console\Migrations\FreshCommand as BaseCommand;
 
@@ -20,34 +19,52 @@ class FreshCommand extends BaseCommand
             return;
         }
 
-        $this->input->setOption('force', $force = true);
-        $website_id = $this->option('website_id');
-        $realpath = $this->option('realpath');
-        $path = $this->input->getOption('path');
+        $this->input->setOption('force', true);
+        $this->input->setOption('database', $this->connection->tenantName());
 
-        $website = $this->websites->query()->findOrFail($website_id);
+        $this->processHandle(function (Website $website) {
+            $this->connection->set($website);
 
-        $this->connection->set($website);
+            $this->dropAllTables(
+                $database = $this->connection->tenantName()
+            );
 
-        $this->dropAllTables(
-            $database = $this->connection->tenantName()
-        );
-
-        $this->call('tenancy:migrate', [
-            '--database' => $database,
-            '--realpath' => $realpath,
-            '--website_id' => $website_id,
-            '--path' => $path,
-            '--force' => $force,
-        ]);
-
-        if ($this->needsSeeding()) {
-            $this->call('tenancy:db:seed', [
+            $this->call('tenancy:migrate', [
                 '--database' => $database,
-                '--class' => $this->option('seeder') ?? config('tenancy.db.tenant-seed-class') ?? 'DatabaseSeeder',
-                '--force' => $force,
+                '--website_id' => [$website->id],
+                '--path' => $this->option('path'),
+                '--realpath' => $this->option('realpath'),
+                '--force' => 1,
             ]);
+
+            if ($this->needsSeeding()) {
+                $this->call('tenancy:db:seed', [
+                    '--database' => $database,
+                    '--website_id' => [$website->id],
+                    '--class' => $this->option('seeder'),
+                    '--force' => 1,
+                ]);
+            }
+
+            $this->connection->purge();
+        });
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        foreach ($options = parent::getOptions() as $option) {
+            if ($option[0] === 'seeder') {
+                $option[4] = config('tenancy.db.tenant-seed-class', null);
+            }
         }
 
+        return array_merge($options, [
+            $this->addWebsiteOption()
+        ]);
     }
 }

--- a/src/Database/Console/Migrations/FreshCommand.php
+++ b/src/Database/Console/Migrations/FreshCommand.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
 namespace Hyn\Tenancy\Database\Console\Migrations;
 
 use http\Exception\RuntimeException;
@@ -48,6 +60,5 @@ class FreshCommand extends BaseCommand
                 '--force' => $force,
             ]);
         }
-
     }
 }

--- a/tests/traits/InteractsWithMigrations.php
+++ b/tests/traits/InteractsWithMigrations.php
@@ -43,19 +43,21 @@ trait InteractsWithMigrations
             '--force' => 1
         ]);
     }
+
     /**
-     * @param string $command
+     * @param string        $command
      * @param callable|null $callback
      * @param callable|null $hook
+     * @param array         $commandOptions
      */
-    protected function migrateAndTest(string $command, callable $callback = null, callable $hook = null)
+    protected function migrateAndTest(string $command, callable $callback = null, callable $hook = null, array $commandOptions = [])
     {
-        $code = $this->artisan("tenancy:$command", [
+        $code = $this->artisan("tenancy:$command", array_merge([
             '--realpath' => true,
             '--path' => __DIR__ . '/../migrations',
             '--no-interaction' => 1,
             '--force' => true
-        ]);
+        ], $commandOptions));
 
         $this->assertEquals(0, $code, "tenancy:$command didn't work out");
 

--- a/tests/unit-tests/Commands/FreshCommandTest.php
+++ b/tests/unit-tests/Commands/FreshCommandTest.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
 namespace Hyn\Tenancy\Tests\Commands;
 
 use Hyn\Tenancy\Database\Console\Migrations\FreshCommand;

--- a/tests/unit-tests/Commands/FreshCommandTest.php
+++ b/tests/unit-tests/Commands/FreshCommandTest.php
@@ -4,6 +4,8 @@ namespace Hyn\Tenancy\Tests\Commands;
 
 use Hyn\Tenancy\Database\Console\Migrations\FreshCommand;
 use Hyn\Tenancy\Models\Website;
+use Illuminate\Contracts\Foundation\Application;
+use SampleSeeder;
 
 class FreshCommandTest extends DatabaseCommandTest
 {
@@ -23,8 +25,6 @@ class FreshCommandTest extends DatabaseCommandTest
      */
     public function runs_fresh_on_tenants()
     {
-        $this->migrateAndTest('migrate');
-
         $this->migrateAndTest('migrate:fresh', function (Website $website) {
             $this->connection->set($website);
             $this->assertTrue(
@@ -39,14 +39,20 @@ class FreshCommandTest extends DatabaseCommandTest
      */
     public function runs_fresh_with_seeding_on_tenants()
     {
-        $this->seedAndTest('migrate');
-
-        $this->seedAndTest('migrate:fresh', function (Website $website) {
+        $this->migrateAndTest('migrate:fresh', function (Website $website) {
             $this->connection->set($website);
             $this->assertTrue(
                 $this->connection->get()->getSchemaBuilder()->hasTable('samples'),
                 "Connection for {$website->uuid} has no table samples"
             );
-        });
+        }, null, [
+            '--seed' => 1,
+            '--seeder' => SampleSeeder::class
+        ]);
+    }
+
+    protected function duringSetUp(Application $app)
+    {
+        $this->setUpWebsites(true);
     }
 }


### PR DESCRIPTION
@mintunitish so a few considerations:

- The `AddWebsiteFilterOnCommand` trait auto-added by the `MutatesMigrationCommands` added an option `website_id` expected to be an array; the `findOrFail()` call to the `websites` repository therefor would return a collection.
- The test ran `seedAndTest` but you should take care of seeding with the Fresh command; so I've reverted that to `migrateAndTest` and allowed that method to accept command options, so we can give it the `seed` and `seeder` options.
- The test had no existing websites to run any migrations on, so I've added a `setUpWebsites(true)` call.

Hope this clarifies the confusion. 