### PR TITLE
Add tenant-aware logger

### DIFF
--- a/src/Logging/TenantAwareLogger.php
+++ b/src/Logging/TenantAwareLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Hyn\Tenancy\Logging;
+
+use Monolog\Logger;
+use Illuminate\Support\Carbon;
+use Hyn\Tenancy\Website\Directory;
+use Monolog\Handler\StreamHandler;
+
+class TenantAwareLogger
+{
+    /**
+     * Create a custom Monolog instance and pipe logs to the tenant directory.
+     *
+     * @param  array  $config
+     * @return \Monolog\Logger
+     */
+    public function __invoke(array $config)
+    {
+        $log = new Logger('tenant');
+        $level = $log->toMonologLevel($config['level'] ?: 'debug');
+        $tenantDirectory = app(Directory::class);
+        $directoryPath = $tenantDirectory->getWebsite() ? 'app/tenancy/tenants/' . $tenantDirectory->path() : null;
+
+        $logPath = storage_path($directoryPath . 'logs/' . $config['level'] . '_' . Carbon::now()->toDateString() . '.log');
+        $log->pushHandler(new StreamHandler($logPath, $level));
+
+        return $log;
+    }
+}


### PR DESCRIPTION
I have created a tenant-aware logger with the following behavior:

If a valid hostname is detected it will create a _logs_ folder within the tenant directory ie.:
**app/tenancy/tenants/xxxx-xxxxxxxx-xxxx-xxxx/logs/{log_level}_xxxx-xx-xx.log**

If no valid hostname is detected it will default to:
 **/storage/logs/{log_level}_xxxx-xx-xx.log**

In order to activate the logger, you need to add the tenant channel in **config/logging.php** and change or add the stack.channels from single to tenant.
```
...
'channels' => [
        'stack' => [
            'driver' => 'stack',
            'channels' => ['single', 'tenant'],
        ],
        'tenant' => [
            'driver' => 'custom',
            'via' => Hyn\Tenancy\Logging\TenantAwareLogger::class,
            'level' => 'debug',
        ],
...
```

Hope this helps!

Best Regards
Janis