### PR TITLE
Update Directory.php

### DIFF
--- a/src/Website/Directory.php
+++ b/src/Website/Directory.php
@@ -207,6 +207,7 @@ class Directory implements Filesystem
                     return $this->path($path);
                 })
                 ->values()
+                ->all()
         );
     }
 


### PR DESCRIPTION
In the delete method of this Directory class, I noticed it uses Laravel Collections, which isn't what Illuminate FileSystemAdapter expects.

If you take a look at the below URL from Illuminate:
https://github.com/laravel/framework/blob/5.6/src/Illuminate/Filesystem/FilesystemAdapter.php#L292

Notice it either takes a string or an array. If you pass in a collection, it'll evaluate "is_array($paths)" to false.
Thus, the delete would always throw a file not found exception due to incorrect handling.

I've made minor changes so the collection is converted to an array of paths, using the all() method of collections.