### PR TITLE
Allow custom/own mimes for Media controller

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -376,5 +376,16 @@ return [
              */
             'override-global' => true,
         ]
+    ],
+    /**
+     * MIMES configuration for media folder via controller
+     * In some cases especially shared host does not support the full list of mimes, here you can define all you like
+     * If you do not need this feature please comment
+     */
+    /*
+    'mimes' => [
+        'css'   =>  'text/css',
+        'js'    =>  'text/javascript'
     ]
+    */
 ];

--- a/src/Controllers/MediaController.php
+++ b/src/Controllers/MediaController.php
@@ -42,20 +42,14 @@ class MediaController
         $path = "media/$path";
 
         if ($this->directory->exists($path)) {
-
             $mimetype = Storage::disk('tenant')->mimeType($path);
 
             if (config('tenancy.mimes')){
                 // Unfortunately, some shared hoster have limited mime type support, so we need to improve that by our self.
                 $fileextension = pathinfo($path)['extension'];
 
-                $mimes = [
-                    'css' => 'text/css',
-                    'js' => 'text/javascript'
-                ];
-
-                if (isset($mimes[$fileextension])) {
-                    $mimetype = $mimes[$fileextension];
+                if (isset(config('tenancy.mimes')[$fileextension])) {
+                    $mimetype = config('tenancy.mimes')[$fileextension];
                 }
             }
 

--- a/src/Controllers/MediaController.php
+++ b/src/Controllers/MediaController.php
@@ -42,8 +42,25 @@ class MediaController
         $path = "media/$path";
 
         if ($this->directory->exists($path)) {
+
+            $mimetype = Storage::disk('tenant')->mimeType($path);
+
+            if (config('tenancy.mimes')){
+                // Unfortunately, some shared hoster have limited mime type support, so we need to improve that by our self.
+                $fileextension = pathinfo($path)['extension'];
+
+                $mimes = [
+                    'css' => 'text/css',
+                    'js' => 'text/javascript'
+                ];
+
+                if (isset($mimes[$fileextension])) {
+                    $mimetype = $mimes[$fileextension];
+                }
+            }
+
             return response($this->directory->get($path))
-                ->header('Content-Type', Storage::disk('tenant')->mimeType($path));
+                ->header('Content-Type', $mimetype);
         }
 
         return abort(404);

--- a/src/Controllers/MediaController.php
+++ b/src/Controllers/MediaController.php
@@ -44,7 +44,7 @@ class MediaController
         if ($this->directory->exists($path)) {
             $mimetype = Storage::disk('tenant')->mimeType($path);
 
-            if (config('tenancy.mimes')){
+            if (config('tenancy.mimes')) {
                 // Unfortunately, some shared hoster have limited mime type support, so we need to improve that by our self.
                 $fileextension = pathinfo($path)['extension'];
 


### PR DESCRIPTION
Allow MIMES configuration for media folder via controller
as in some cases, especially shared host does not support the full list of mimes, here you can define all you like