### PR TITLE
Add connection to table creation

### DIFF
--- a/assets/migrations/2017_01_01_000003_tenancy_websites.php
+++ b/assets/migrations/2017_01_01_000003_tenancy_websites.php
@@ -12,9 +12,9 @@
  * @see https://github.com/hyn/multi-tenant
  */
 
-use Hyn\Tenancy\Abstracts\AbstractMigration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Hyn\Tenancy\Abstracts\AbstractMigration;
 
 class TenancyWebsites extends AbstractMigration
 {
@@ -22,7 +22,7 @@ class TenancyWebsites extends AbstractMigration
 
     public function up()
     {
-        Schema::create('websites', function (Blueprint $table) {
+        Schema::connection('system')->create('websites', function (Blueprint $table) {
             $table->bigIncrements('id');
 
             $table->string('uuid');
@@ -34,6 +34,6 @@ class TenancyWebsites extends AbstractMigration
 
     public function down()
     {
-        Schema::dropIfExists('websites');
+        Schema::connection('system')->dropIfExists('websites');
     }
 }

--- a/assets/migrations/2017_01_01_000003_tenancy_websites.php
+++ b/assets/migrations/2017_01_01_000003_tenancy_websites.php
@@ -12,6 +12,7 @@
  * @see https://github.com/hyn/multi-tenant
  */
 
+use Hyn\Tenancy\Database\Connection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Hyn\Tenancy\Abstracts\AbstractMigration;
@@ -22,7 +23,7 @@ class TenancyWebsites extends AbstractMigration
 
     public function up()
     {
-        Schema::connection('system')->create('websites', function (Blueprint $table) {
+        Schema::connection(app(Connection::class)->systemName())->create('websites', function (Blueprint $table) {
             $table->bigIncrements('id');
 
             $table->string('uuid');

--- a/assets/migrations/2017_01_01_000005_tenancy_hostnames.php
+++ b/assets/migrations/2017_01_01_000005_tenancy_hostnames.php
@@ -12,6 +12,7 @@
  * @see https://github.com/hyn/multi-tenant
  */
 
+use Hyn\Tenancy\Database\Connection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Hyn\Tenancy\Abstracts\AbstractMigration;
@@ -22,7 +23,7 @@ class TenancyHostnames extends AbstractMigration
 
     public function up()
     {
-        Schema::connection('system')->create('hostnames', function (Blueprint $table) {
+        Schema::connection(app(Connection::class)->systemName())->create('hostnames', function (Blueprint $table) {
             $table->bigIncrements('id');
 
             $table->string('fqdn')->unique();

--- a/assets/migrations/2017_01_01_000005_tenancy_hostnames.php
+++ b/assets/migrations/2017_01_01_000005_tenancy_hostnames.php
@@ -12,9 +12,9 @@
  * @see https://github.com/hyn/multi-tenant
  */
 
-use Hyn\Tenancy\Abstracts\AbstractMigration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Hyn\Tenancy\Abstracts\AbstractMigration;
 
 class TenancyHostnames extends AbstractMigration
 {
@@ -22,7 +22,7 @@ class TenancyHostnames extends AbstractMigration
 
     public function up()
     {
-        Schema::create('hostnames', function (Blueprint $table) {
+        Schema::connection('system')->create('hostnames', function (Blueprint $table) {
             $table->bigIncrements('id');
 
             $table->string('fqdn')->unique();
@@ -40,6 +40,6 @@ class TenancyHostnames extends AbstractMigration
 
     public function down()
     {
-        Schema::dropIfExists('hostnames');
+        Schema::connection('system')->dropIfExists('hostnames');
     }
 }

--- a/assets/migrations/2018_04_06_000001_tenancy_websites_needs_db_host.php
+++ b/assets/migrations/2018_04_06_000001_tenancy_websites_needs_db_host.php
@@ -12,6 +12,7 @@
  * @see https://github.com/hyn/multi-tenant
  */
 
+use Hyn\Tenancy\Database\Connection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Hyn\Tenancy\Abstracts\AbstractMigration;
@@ -22,7 +23,7 @@ class TenancyWebsitesNeedsDbHost extends AbstractMigration
 
     public function up()
     {
-        Schema::connection('system')->table('websites', function (Blueprint $table) {
+        Schema::connection(app(Connection::class)->systemName())->table('websites', function (Blueprint $table) {
             $table->string('managed_by_database_connection')
                 ->nullable()
                 ->comment('References the database connection key in your database.php');

--- a/assets/migrations/2018_04_06_000001_tenancy_websites_needs_db_host.php
+++ b/assets/migrations/2018_04_06_000001_tenancy_websites_needs_db_host.php
@@ -12,9 +12,9 @@
  * @see https://github.com/hyn/multi-tenant
  */
 
-use Hyn\Tenancy\Abstracts\AbstractMigration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Hyn\Tenancy\Abstracts\AbstractMigration;
 
 class TenancyWebsitesNeedsDbHost extends AbstractMigration
 {
@@ -22,7 +22,7 @@ class TenancyWebsitesNeedsDbHost extends AbstractMigration
 
     public function up()
     {
-        Schema::table('websites', function (Blueprint $table) {
+        Schema::connection('system')->table('websites', function (Blueprint $table) {
             $table->string('managed_by_database_connection')
                 ->nullable()
                 ->comment('References the database connection key in your database.php');
@@ -31,7 +31,7 @@ class TenancyWebsitesNeedsDbHost extends AbstractMigration
 
     public function down()
     {
-        Schema::table('websites', function (Blueprint $table) {
+        Schema::connection('system')->table('websites', function (Blueprint $table) {
             $table->dropColumn('managed_by_database_connection');
         });
     }


### PR DESCRIPTION
By specifying the `system` connection the tables are more obviously created on the system database.
I ran into this when using this package in an existing application, where it would have ran on a database that is not the system one.