### PR TITLE
Disable bubble option in StreamHandler of TenantAwareLogger

### DIFF
--- a/src/Generators/Filesystem/DirectoryGenerator.php
+++ b/src/Generators/Filesystem/DirectoryGenerator.php
@@ -60,9 +60,9 @@ class DirectoryGenerator
                 $this->emitEvent(
                     new DirectoryCreated($event->website, $this->filesystem())
                 );
+            } else {
+                logs()->error("Failed creating directory for tenant ({$event->website->id}) {$event->website->uuid}.");
             }
-
-            return $stat;
         }
 
         return true;
@@ -86,9 +86,9 @@ class DirectoryGenerator
                     (new DirectoryRenamed($event->website, $this->filesystem()))
                         ->setOld($uuid)
                 );
+            } else {
+                logs()->error("Failed updating directory for tenant ({$event->website->id}) {$event->website->uuid}.");
             }
-
-            return $stat;
         }
 
         return true;
@@ -109,9 +109,9 @@ class DirectoryGenerator
                 $this->emitEvent(
                     new DirectoryDeleted($event->website, $this->filesystem())
                 );
+            } else {
+                logs()->error("Failed deleting directory for tenant ({$event->website->id}) {$event->website->uuid}.");
             }
-
-            return $stat;
         }
 
         return true;

--- a/src/Listeners/Database/ConnectsTenants.php
+++ b/src/Listeners/Database/ConnectsTenants.php
@@ -44,10 +44,11 @@ class ConnectsTenants
      * Reacts to this service when we switch the active tenant website.
      *
      * @param WebsiteEvent $event
-     * @return bool
      */
-    public function switch(WebsiteEvent $event) : bool
+    public function switch(WebsiteEvent $event)
     {
-        return $this->connection->set($event->website);
+        if (! $this->connection->set($event->website)) {
+            logs()->error("Failed switching database for tenant ({$event->website->id}) {$event->website->uuid}.");
+        }
     }
 }

--- a/src/Listeners/Database/SeedsTenants.php
+++ b/src/Listeners/Database/SeedsTenants.php
@@ -49,7 +49,7 @@ class SeedsTenants
         $class = config('tenancy.db.tenant-seed-class');
 
         if ($class && class_exists($class)) {
-            if(! $this->connection->seed($event->website, $class)) {
+            if (! $this->connection->seed($event->website, $class)) {
                 logs()->error("Failed seeding database for tenant ({$event->website->id}) {$event->website->uuid}.");
             }
         }

--- a/src/Listeners/Database/SeedsTenants.php
+++ b/src/Listeners/Database/SeedsTenants.php
@@ -49,7 +49,9 @@ class SeedsTenants
         $class = config('tenancy.db.tenant-seed-class');
 
         if ($class && class_exists($class)) {
-            return $this->connection->seed($event->website, $class);
+            if(! $this->connection->seed($event->website, $class)) {
+                logs()->error("Failed seeding database for tenant ({$event->website->id}) {$event->website->uuid}.");
+            }
         }
 
         return true;

--- a/src/Logging/TenantAwareLogger.php
+++ b/src/Logging/TenantAwareLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Hyn\Tenancy\Logging;
+
+use Monolog\Logger;
+use Illuminate\Support\Carbon;
+use Hyn\Tenancy\Website\Directory;
+use Monolog\Handler\StreamHandler;
+
+class TenantAwareLogger
+{
+    /**
+     * Create a custom Monolog instance and pipe logs to the tenant directory.
+     *
+     * @param  array  $config
+     * @return \Monolog\Logger
+     */
+    public function __invoke(array $config)
+    {
+        $log = new Logger('tenant');
+        $level = $log->toMonologLevel($config['level'] ?: 'debug');
+        $tenantDirectory = app(Directory::class);
+        $directoryPath = $tenantDirectory->getWebsite() ? 'app/tenancy/tenants/' . $tenantDirectory->path() : null;
+
+        $logPath = storage_path($directoryPath . 'logs/' . $config['level'] . '_' . Carbon::now()->toDateString() . '.log');
+        $log->pushHandler(new StreamHandler($logPath, $level));
+
+        return $log;
+    }
+}

--- a/src/Logging/TenantAwareLogger.php
+++ b/src/Logging/TenantAwareLogger.php
@@ -35,7 +35,7 @@ class TenantAwareLogger
         $directoryPath = $tenantDirectory->getWebsite() ? 'app/tenancy/tenants/' . $tenantDirectory->path() : null;
 
         $logPath = storage_path($directoryPath . 'logs/' . $config['level'] . '_' . Carbon::now()->toDateString() . '.log');
-        $log->pushHandler(new StreamHandler($logPath, $level));
+        $log->pushHandler(new StreamHandler($logPath, $level, false));
 
         return $log;
     }


### PR DESCRIPTION
Disable bubble option in StreamHandler of TenantAwareLogger in order to prevent empty brackets on log lines.