### PR TITLE
Disable bubble option in StreamHandler of TenantAwareLogger

### DIFF
--- a/src/Logging/TenantAwareLogger.php
+++ b/src/Logging/TenantAwareLogger.php
@@ -35,7 +35,7 @@ class TenantAwareLogger
         $directoryPath = $tenantDirectory->getWebsite() ? 'app/tenancy/tenants/' . $tenantDirectory->path() : null;
 
         $logPath = storage_path($directoryPath . 'logs/' . $config['level'] . '_' . Carbon::now()->toDateString() . '.log');
-        $log->pushHandler(new StreamHandler($logPath, $level));
+        $log->pushHandler(new StreamHandler($logPath, $level, false));
 
         return $log;
     }


### PR DESCRIPTION
Disable bubble option in StreamHandler of TenantAwareLogger in order to prevent empty brackets at the end of log lines. 