### PR TITLE
Schema division mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ references:
             - run: DB_CONNECTION=mysql DB_HOST=mariadb TENANCY_SYSTEM_CONNECTION_NAME=mysql ./vendor/bin/phpunit -c ci.phpunit.xml
             - run: DB_CONNECTION=mysql DB_HOST=mysql LIMIT_UUID_LENGTH_32=1 TENANCY_SYSTEM_CONNECTION_NAME=mysql ./vendor/bin/phpunit -c ci.phpunit.xml
             - run: DB_CONNECTION=pgsql DB_HOST=pgsql TENANCY_SYSTEM_CONNECTION_NAME=pgsql ./vendor/bin/phpunit -c ci.phpunit.xml
+            - run: DB_CONNECTION=pgsql DB_HOST=pgsql TENANCY_SYSTEM_CONNECTION_NAME=pgsql TENANCY_DATABASE_DIVISION_MODE=schema ./vendor/bin/phpunit -c ci.phpunit.xml ./tests/unit-tests/Database
 
     mysql_environment: &mysql_environment
         - MYSQL_DATABASE: testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ references:
             - run: DB_CONNECTION=mysql DB_HOST=mariadb TENANCY_SYSTEM_CONNECTION_NAME=mysql ./vendor/bin/phpunit -c ci.phpunit.xml
             - run: DB_CONNECTION=mysql DB_HOST=mysql LIMIT_UUID_LENGTH_32=1 TENANCY_SYSTEM_CONNECTION_NAME=mysql ./vendor/bin/phpunit -c ci.phpunit.xml
             - run: DB_CONNECTION=pgsql DB_HOST=pgsql TENANCY_SYSTEM_CONNECTION_NAME=pgsql ./vendor/bin/phpunit -c ci.phpunit.xml
-            - run: DB_CONNECTION=pgsql DB_HOST=pgsql TENANCY_SYSTEM_CONNECTION_NAME=pgsql TENANCY_DATABASE_DIVISION_MODE=schema ./vendor/bin/phpunit -c ci.phpunit.xml ./tests/unit-tests/Database
+            - run: DB_CONNECTION=pgsql DB_HOST=pgsql TENANCY_SYSTEM_CONNECTION_NAME=pgsql TENANCY_DATABASE_DIVISION_MODE=schema ./vendor/bin/phpunit -c ci.phpunit.xml ./tests/unit-tests/Database/ConnectionTest.php
 
     mysql_environment: &mysql_environment
         - MYSQL_DATABASE: testing

--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -184,8 +184,11 @@ return [
         /**
          * The tenant division mode specifies to what database websites will be
          * connecting. The default setup is to use a new database per tenant.
+         * If using PostgreSQL, a new schema per tenant in the same database can
+         * be setup, by optionally setting division mode to 'schema'.
          * In case you prefer to use the same database with a table prefix,
          * set the mode to 'prefix'.
+         * To implement a custom division mode, set this to 'bypass'.
          *
          * @see src/Database/Connection.php
          */

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -45,6 +45,11 @@ class Connection
     const DIVISION_MODE_SEPARATE_PREFIX = 'prefix';
 
     /**
+     * Allows division by schema. Postges only.
+     */
+    const DIVISION_MODE_SEPARATE_SCHEMA = 'schema';
+
+    /**
      * Allows manually setting the configuration during event callbacks.
      */
     const DIVISION_MODE_BYPASS = 'bypass';
@@ -314,6 +319,10 @@ class Connection
                 break;
             case static::DIVISION_MODE_SEPARATE_PREFIX:
                 $clone['prefix'] = sprintf('%d_', $website->id);
+                break;
+            case static::DIVISION_MODE_SEPARATE_SCHEMA:
+                $clone['username'] = $clone['schema'] = $website->uuid;
+                $clone['password'] = $this->passwordGenerator->generate($website);
                 break;
             case static::DIVISION_MODE_BYPASS:
                 break;

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -66,7 +66,9 @@ class DatabaseGenerator
 
         switch ($driver) {
             case 'pgsql':
-                return $this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA ? new Drivers\PostgresSchema : new Drivers\PostgreSQL;
+                return $this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA 
+                    ? new Drivers\PostgresSchema 
+                    : new Drivers\PostgreSQL;
                 break;
             case 'mysql':
                 return new Drivers\MariaDB;

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -66,6 +66,9 @@ class DatabaseGenerator
 
         switch ($driver) {
             case 'pgsql':
+                if ($this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA) {
+                    return new Drivers\PostgresSchema;
+                }
                 return new Drivers\PostgreSQL;
                 break;
             case 'mysql':
@@ -86,7 +89,10 @@ class DatabaseGenerator
             return;
         }
 
-        if ($this->mode !== Connection::DIVISION_MODE_SEPARATE_DATABASE) {
+        if (!in_array($this->mode, [
+            Connection::DIVISION_MODE_SEPARATE_DATABASE,
+            Connection::DIVISION_MODE_SEPARATE_SCHEMA,
+        ])) {
             return;
         }
 
@@ -131,7 +137,10 @@ class DatabaseGenerator
             return;
         }
 
-        if ($this->mode !== Connection::DIVISION_MODE_SEPARATE_DATABASE) {
+        if (!in_array($this->mode, [
+            Connection::DIVISION_MODE_SEPARATE_DATABASE,
+            Connection::DIVISION_MODE_SEPARATE_SCHEMA,
+        ])) {
             return;
         }
 
@@ -162,7 +171,10 @@ class DatabaseGenerator
             return;
         }
 
-        if ($this->mode !== Connection::DIVISION_MODE_SEPARATE_DATABASE) {
+        if (!in_array($this->mode, [
+            Connection::DIVISION_MODE_SEPARATE_DATABASE,
+            Connection::DIVISION_MODE_SEPARATE_SCHEMA,
+        ])) {
             return;
         }
 
@@ -181,7 +193,7 @@ class DatabaseGenerator
         );
 
         if (!$this->driver($config)->updated($event, $config, $this->connection)) {
-            throw new GeneratorFailedException("Could not delete database {$config['database']}, the statement failed.");
+            throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");
         }
 
         $this->emitEvent(

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -66,10 +66,7 @@ class DatabaseGenerator
 
         switch ($driver) {
             case 'pgsql':
-                if ($this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA) {
-                    return new Drivers\PostgresSchema;
-                }
-                return new Drivers\PostgreSQL;
+            	return $this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA ? new Drivers\PostgresSchema : new Drivers\PostgreSQL;
                 break;
             case 'mysql':
                 return new Drivers\MariaDB;

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -66,7 +66,7 @@ class DatabaseGenerator
 
         switch ($driver) {
             case 'pgsql':
-            	return $this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA ? new Drivers\PostgresSchema : new Drivers\PostgreSQL;
+                return $this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA ? new Drivers\PostgresSchema : new Drivers\PostgreSQL;
                 break;
             case 'mysql':
                 return new Drivers\MariaDB;

--- a/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
@@ -35,16 +35,21 @@ class PostgreSQL implements DatabaseGenerator
     {
         $connection = $connection->system($event->website);
 
-        return
-            $this->createUser($connection, $config) &&
-            $this->createDatabase($connection, $config) &&
-            $this->grantPrivileges($connection, $config);
+        $createUser = config('tenancy.db.auto-create-tenant-database-user');
+
+        if ($createUser) {
+            return
+                $this->createUser($connection, $config) &&
+                $this->createDatabase($connection, $config) &&
+                $this->grantPrivileges($connection, $config);
+        } else {
+            return $this->createDatabase($connection, $config);
+        }   
     }
 
     protected function createUser(IlluminateConnection $connection, array $config)
     {
-        if (config('tenancy.db.auto-create-tenant-database-user') && !$this->userExists($connection,
-                $config['username'])) {
+        if (!$this->userExists($connection, $config['username'])) {
             return $connection->statement("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'");
         }
 

--- a/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
@@ -33,24 +33,29 @@ class PostgreSQL implements DatabaseGenerator
      */
     public function created(Created $event, array $config, Connection $connection): bool
     {
-        $user   = function (IlluminateConnection $connection) use ($config) {
-            if (config('tenancy.db.auto-create-tenant-database-user') && !$this->userExists($connection,
-                    $config['username'])) {
-                return $connection->statement("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'");
-            }
-
-            return true;
-        };
-        $create = function (IlluminateConnection $connection) use ($config) {
-            return $connection->statement("CREATE DATABASE \"{$config['database']}\"");
-        };
-        $grant  = function (IlluminateConnection $connection) use ($config) {
-            return $connection->statement("GRANT ALL PRIVILEGES ON DATABASE \"{$config['database']}\" TO \"{$config['username']}\"");
-        };
-
         $connection = $connection->system($event->website);
 
-        return $user($connection) && $create($connection) && $grant($connection);
+        return
+            $this->createUser($connection, $config) &&
+            $this->createDatabase($connection, $config) &&
+            $this->grantPrivileges($connection, $config);
+    }
+
+    protected function createUser (IlluminateConnection $connection, array $config) {
+        if (config('tenancy.db.auto-create-tenant-database-user') && !$this->userExists($connection,
+                $config['username'])) {
+            return $connection->statement("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'");
+        }
+
+        return true;
+    }
+
+    protected function createDatabase (IlluminateConnection $connection, array $config) {
+        return $connection->statement("CREATE DATABASE \"{$config['database']}\"");
+    }
+
+    protected function grantPrivileges (IlluminateConnection $connection, array $config) {
+        return $connection->statement("GRANT ALL PRIVILEGES ON DATABASE \"{$config['database']}\" TO \"{$config['username']}\"");
     }
 
     protected function userExists($connection, string $username): bool
@@ -72,7 +77,7 @@ class PostgreSQL implements DatabaseGenerator
         $uuid = Arr::get($event->dirty, 'uuid');
 
         if (!$connection->system($event->website)->statement("ALTER DATABASE \"$uuid\" RENAME TO \"{$config['database']}\"")) {
-            throw new GeneratorFailedException("Could not delete database {$config['database']}, the statement failed.");
+            throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");
         }
 
         return true;
@@ -92,40 +97,48 @@ class PostgreSQL implements DatabaseGenerator
             $connection->get()->disconnect();
         }
 
-        $flush = function (IlluminateConnection $connection) use ($config) {
-            $connection
-                ->table('pg_stat_activity')
-                ->select($connection->raw('pg_terminate_backend(pid)'))
-                ->where('datname', $config['database'])
-                ->where('pid', '<>', $connection->raw('pg_backend_pid()'))
-                ->get();
-
-            return true;
-        };
-
-        $user = function (IlluminateConnection $connection) use ($config) {
-            if (config('tenancy.db.auto-delete-tenant-database-user') && $this->userExists($connection,
-                    $config['username'])) {
-                return $connection->statement("DROP USER \"{$config['username']}\"");
-            }
-
-            return true;
-        };
-
-        $grant = function (IlluminateConnection $connection) use ($config) {
-            if ($this->userExists($connection, $config['username'])) {
-                return $connection->statement("DROP OWNED BY \"{$config['username']}\"");
-            }
-
-            return true;
-        };
-
-        $delete = function (IlluminateConnection $connection) use ($config) {
-            return $connection->statement("DROP DATABASE IF EXISTS \"{$config['database']}\"");
-        };
-
         $connection = $connection->system($event->website);
 
-        return $flush($connection) && $grant($connection) && $delete($connection) && $user($connection);
+        return
+            $this->flushConnection($connection, $config) &&
+            $this->dropPriviliges($connection, $config) &&
+            $this->dropDatabase($connection, $config) &&
+            $this->dropUser($connection, $config);
+    }
+
+    protected function flushConnection (IlluminateConnection $connection, array $config)
+    {
+        $connection
+            ->table('pg_stat_activity')
+            ->select($connection->raw('pg_terminate_backend(pid)'))
+            ->where('datname', $config['database'])
+            ->where('pid', '<>', $connection->raw('pg_backend_pid()'))
+            ->get();
+
+        return true;
+    }
+
+    protected function dropPriviliges (IlluminateConnection $connection, array $config)
+    {
+        if ($this->userExists($connection, $config['username'])) {
+            return $connection->statement("DROP OWNED BY \"{$config['username']}\"");
+        }
+
+        return true;
+    }
+
+    protected function dropDatabase (IlluminateConnection $connection, array $config)
+    {
+        return $connection->statement("DROP DATABASE IF EXISTS \"{$config['database']}\"");
+    }
+
+    protected function dropUser (IlluminateConnection $connection, array $config)
+    {
+        if (config('tenancy.db.auto-delete-tenant-database-user') && $this->userExists($connection,
+                $config['username'])) {
+            return $connection->statement("DROP USER \"{$config['username']}\"");
+        }
+
+        return true;
     }
 }

--- a/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
@@ -41,7 +41,8 @@ class PostgreSQL implements DatabaseGenerator
             $this->grantPrivileges($connection, $config);
     }
 
-    protected function createUser (IlluminateConnection $connection, array $config) {
+    protected function createUser(IlluminateConnection $connection, array $config)
+    {
         if (config('tenancy.db.auto-create-tenant-database-user') && !$this->userExists($connection,
                 $config['username'])) {
             return $connection->statement("CREATE USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'");
@@ -50,11 +51,13 @@ class PostgreSQL implements DatabaseGenerator
         return true;
     }
 
-    protected function createDatabase (IlluminateConnection $connection, array $config) {
+    protected function createDatabase(IlluminateConnection $connection, array $config)
+    {
         return $connection->statement("CREATE DATABASE \"{$config['database']}\"");
     }
 
-    protected function grantPrivileges (IlluminateConnection $connection, array $config) {
+    protected function grantPrivileges(IlluminateConnection $connection, array $config)
+    {
         return $connection->statement("GRANT ALL PRIVILEGES ON DATABASE \"{$config['database']}\" TO \"{$config['username']}\"");
     }
 
@@ -106,7 +109,7 @@ class PostgreSQL implements DatabaseGenerator
             $this->dropUser($connection, $config);
     }
 
-    protected function flushConnection (IlluminateConnection $connection, array $config)
+    protected function flushConnection(IlluminateConnection $connection, array $config)
     {
         $connection
             ->table('pg_stat_activity')
@@ -118,7 +121,7 @@ class PostgreSQL implements DatabaseGenerator
         return true;
     }
 
-    protected function dropPriviliges (IlluminateConnection $connection, array $config)
+    protected function dropPriviliges(IlluminateConnection $connection, array $config)
     {
         if ($this->userExists($connection, $config['username'])) {
             return $connection->statement("DROP OWNED BY \"{$config['username']}\"");
@@ -127,12 +130,12 @@ class PostgreSQL implements DatabaseGenerator
         return true;
     }
 
-    protected function dropDatabase (IlluminateConnection $connection, array $config)
+    protected function dropDatabase(IlluminateConnection $connection, array $config)
     {
         return $connection->statement("DROP DATABASE IF EXISTS \"{$config['database']}\"");
     }
 
-    protected function dropUser (IlluminateConnection $connection, array $config)
+    protected function dropUser(IlluminateConnection $connection, array $config)
     {
         if (config('tenancy.db.auto-delete-tenant-database-user') && $this->userExists($connection,
                 $config['username'])) {

--- a/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
@@ -15,8 +15,6 @@
 namespace Hyn\Tenancy\Generators\Webserver\Database\Drivers;
 
 use Hyn\Tenancy\Database\Connection;
-use Hyn\Tenancy\Events\Websites\Created;
-use Hyn\Tenancy\Events\Websites\Deleted;
 use Hyn\Tenancy\Events\Websites\Updated;
 use Hyn\Tenancy\Exceptions\GeneratorFailedException;
 use Illuminate\Database\Connection as IlluminateConnection;
@@ -24,11 +22,13 @@ use Illuminate\Support\Arr;
 
 class PostgresSchema extends PostgreSQL
 {
-    protected function createDatabase (IlluminateConnection $connection, array $config) {
+    protected function createDatabase(IlluminateConnection $connection, array $config)
+    {
         return $connection->statement("CREATE SCHEMA \"{$config['schema']}\"");
     }
 
-    protected function grantPrivileges (IlluminateConnection $connection, array $config) {
+    protected function grantPrivileges(IlluminateConnection $connection, array $config)
+    {
         return $connection->statement("GRANT ALL PRIVILEGES ON SCHEMA \"{$config['schema']}\" TO \"{$config['username']}\"");
     }
 
@@ -50,7 +50,7 @@ class PostgresSchema extends PostgreSQL
         return true;
     }
 
-    protected function dropDatabase (IlluminateConnection $connection, array $config)
+    protected function dropDatabase(IlluminateConnection $connection, array $config)
     {
         return $connection->statement("DROP SCHEMA IF EXISTS \"{$config['schema']}\"");
     }

--- a/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Generators\Webserver\Database\Drivers;
+
+use Hyn\Tenancy\Database\Connection;
+use Hyn\Tenancy\Events\Websites\Created;
+use Hyn\Tenancy\Events\Websites\Deleted;
+use Hyn\Tenancy\Events\Websites\Updated;
+use Hyn\Tenancy\Exceptions\GeneratorFailedException;
+use Illuminate\Database\Connection as IlluminateConnection;
+use Illuminate\Support\Arr;
+
+class PostgresSchema extends PostgreSQL
+{
+    protected function createDatabase (IlluminateConnection $connection, array $config) {
+        return $connection->statement("CREATE SCHEMA \"{$config['schema']}\"");
+    }
+
+    protected function grantPrivileges (IlluminateConnection $connection, array $config) {
+        return $connection->statement("GRANT ALL PRIVILEGES ON SCHEMA \"{$config['schema']}\" TO \"{$config['username']}\"");
+    }
+
+    /**
+     * @param Updated    $event
+     * @param array      $config
+     * @param Connection $connection
+     * @return bool
+     * @throws GeneratorFailedException
+     */
+    public function updated(Updated $event, array $config, Connection $connection): bool
+    {
+        $uuid = Arr::get($event->dirty, 'uuid');
+
+        if (!$connection->system($event->website)->statement("ALTER SCHEMA \"$uuid\" RENAME TO \"{$config['schema']}\"")) {
+            throw new GeneratorFailedException("Could not rename schema {$config['schema']}, the statement failed.");
+        }
+
+        return true;
+    }
+
+    protected function dropDatabase (IlluminateConnection $connection, array $config)
+    {
+        return $connection->statement("DROP SCHEMA IF EXISTS \"{$config['schema']}\"");
+    }
+}


### PR DESCRIPTION
Implements feature described in #533 

I created a new DatabaseGenerator driver (`PostgresSchema`) that extends the default Postgres driver. To avoid code duplication, I refactored the postgres driver by extracting each step in creating/deleting databases into separate functions that can be overridden.

To test this new functionality, I added the following line to ci config:

```
DB_CONNECTION=pgsql DB_HOST=pgsql TENANCY_SYSTEM_CONNECTION_NAME=pgsql TENANCY_DATABASE_DIVISION_MODE=schema ./vendor/bin/phpunit -c ci.phpunit.xml ./tests/unit-tests/Database/ConnectionTest.php
```

There might be a better way of testing it, but this seems sufficient.