### PR TITLE
Set Mysql Default Char Set and Collation on create

### DIFF
--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -41,7 +41,9 @@ class MariaDB implements DatabaseGenerator
             return true;
         };
         $create = function ($connection) use ($config) {
-            return $connection->statement("CREATE DATABASE IF NOT EXISTS `{$config['database']}`");
+            return $connection->statement("CREATE DATABASE IF NOT EXISTS `{$config['database']}`
+            DEFAULT CHARACTER SET `{$config['charset']}`
+            DEFAULT COLLATE `{$config['collation']}`");
         };
         $grant = function ($connection) use ($config) {
             return $connection->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -42,8 +42,8 @@ class MariaDB implements DatabaseGenerator
         };
         $create = function ($connection) use ($config) {
             return $connection->statement("CREATE DATABASE IF NOT EXISTS `{$config['database']}`
-            DEFAULT CHARACTER SET `{$config['charset']}`
-            DEFAULT COLLATE `{$config['collation']}`");
+            DEFAULT CHARACTER SET {$config['charset']}
+            DEFAULT COLLATE {$config['collation']}");
         };
         $grant = function ($connection) use ($config) {
             return $connection->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");


### PR DESCRIPTION
I am working on a system where it will be helpful to be able to set Default Character Set and Default Collation by using data from database driver config. This pull request achieves that. I trust you find it acceptable. Otherwise maybe here is some method/setting I missed?