### PR TITLE
Add support for custom database drivers

### DIFF
--- a/src/Generators/Webserver/Database/DatabaseDriverFactory.php
+++ b/src/Generators/Webserver/Database/DatabaseDriverFactory.php
@@ -15,10 +15,11 @@
 namespace Hyn\Tenancy\Generators\Webserver\Database;
 
 use Hyn\Tenancy\Exceptions\GeneratorFailedException;
+use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
 
 class DatabaseDriverFactory
 {
-    public function create($driver = 'mysql')
+    public function create($driver = 'mysql') : DatabaseGenerator
     {
         $drivers = app('tenancy.db.drivers');
 

--- a/src/Generators/Webserver/Database/DatabaseDriverFactory.php
+++ b/src/Generators/Webserver/Database/DatabaseDriverFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Generators\Webserver\Database;
+
+use Hyn\Tenancy\Exceptions\GeneratorFailedException;
+
+class DatabaseDriverFactory
+{
+    public function create($driver = 'mysql')
+    {
+        $drivers = app('tenancy.db.drivers');
+
+        if (!in_array($driver, $drivers->keys()->toArray())) {
+            throw new GeneratorFailedException("Could not generate database for driver $driver");
+        }
+
+        return new $drivers[$driver]();
+    }
+}

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -38,18 +38,18 @@ class DatabaseGenerator
     /**
      * @var DatabaseDriverFactory
      */
-    protected $dbDriverFactory;
+    protected $factory;
 
     /**
      * DatabaseGenerator constructor.
      * @param Connection $connection
-     * @param DatabaseDriverFactory $dbDriverFactory
+     * @param DatabaseDriverFactory $factory
      */
-    public function __construct(Connection $connection, DatabaseDriverFactory $dbDriverFactory)
+    public function __construct(Connection $connection, DatabaseDriverFactory $factory)
     {
         $this->connection = $connection;
         $this->mode = config('tenancy.db.tenant-division-mode');
-        $this->dbDriverFactory = $dbDriverFactory;
+        $this->factory = $factory;
     }
 
     /**
@@ -87,7 +87,7 @@ class DatabaseGenerator
             new Events\Database\Creating($config, $event->website)
         );
 
-        if (!$this->dbDriverFactory->create($config['driver'])->created($event, $config, $this->connection)) {
+        if (!$this->factory->create($config['driver'])->created($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not generate database {$config['database']}, one of the statements failed.");
         }
 
@@ -135,7 +135,7 @@ class DatabaseGenerator
             new Events\Database\Deleting($config, $event->website)
         );
 
-        if (!$this->dbDriverFactory->create($config['driver'])->deleted($event, $config, $this->connection)) {
+        if (!$this->factory->create($config['driver'])->deleted($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not delete database {$config['database']}, the statement failed.");
         }
 
@@ -175,7 +175,7 @@ class DatabaseGenerator
             new Events\Database\Renaming($config, $event->website)
         );
 
-        if (!$this->dbDriverFactory->create($config['driver'])->updated($event, $config, $this->connection)) {
+        if (!$this->factory->create($config['driver'])->updated($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");
         }
 

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -56,29 +56,6 @@ class DatabaseGenerator
     }
 
     /**
-     * @param array $config
-     * @return \Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator
-     * @throws GeneratorFailedException
-     */
-    protected function driver(array $config)
-    {
-        $driver = Arr::get($config, 'driver', 'mysql');
-
-        switch ($driver) {
-            case 'pgsql':
-                return $this->mode === Connection::DIVISION_MODE_SEPARATE_SCHEMA
-                    ? new Drivers\PostgresSchema
-                    : new Drivers\PostgreSQL;
-                break;
-            case 'mysql':
-                return new Drivers\MariaDB;
-                break;
-            default:
-                throw new GeneratorFailedException("Could not generate database for driver $driver");
-        }
-    }
-
-    /**
      * @param Events\Websites\Created $event
      * @throws GeneratorFailedException
      */
@@ -103,7 +80,7 @@ class DatabaseGenerator
             new Events\Database\Creating($config, $event->website)
         );
 
-        if (!$this->driver($config)->created($event, $config, $this->connection)) {
+        if (!app(DatabaseDriverFactory::class)->create($config['driver'])->created($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not generate database {$config['database']}, one of the statements failed.");
         }
 
@@ -151,7 +128,7 @@ class DatabaseGenerator
             new Events\Database\Deleting($config, $event->website)
         );
 
-        if (!$this->driver($config)->deleted($event, $config, $this->connection)) {
+        if (!app(DatabaseDriverFactory::class)->create($config['driver'])->deleted($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not delete database {$config['database']}, the statement failed.");
         }
 
@@ -191,7 +168,7 @@ class DatabaseGenerator
             new Events\Database\Renaming($config, $event->website)
         );
 
-        if (!$this->driver($config)->updated($event, $config, $this->connection)) {
+        if (!app(DatabaseDriverFactory::class)->create($config['driver'])->updated($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");
         }
 

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -38,18 +38,18 @@ class DatabaseGenerator
     /**
      * @var DatabaseDriverFactory
      */
-    protected $databaseDriverFactory;
+    protected $dbDriverFactory;
 
     /**
      * DatabaseGenerator constructor.
      * @param Connection $connection
-     * @param DatabaseDriverFactory $databaseDriverFactory
+     * @param DatabaseDriverFactory $dbDriverFactory
      */
-    public function __construct(Connection $connection, DatabaseDriverFactory $databaseDriverFactory)
+    public function __construct(Connection $connection, DatabaseDriverFactory $dbDriverFactory)
     {
         $this->connection = $connection;
         $this->mode = config('tenancy.db.tenant-division-mode');
-        $this->databaseDriverFactory = $databaseDriverFactory;
+        $this->dbDriverFactory = $dbDriverFactory;
     }
 
     /**
@@ -87,7 +87,7 @@ class DatabaseGenerator
             new Events\Database\Creating($config, $event->website)
         );
 
-        if (!$this->databaseDriverFactory->create($config['driver'])->created($event, $config, $this->connection)) {
+        if (!$this->dbDriverFactory->create($config['driver'])->created($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not generate database {$config['database']}, one of the statements failed.");
         }
 
@@ -135,7 +135,7 @@ class DatabaseGenerator
             new Events\Database\Deleting($config, $event->website)
         );
 
-        if (!$this->databaseDriverFactory->create($config['driver'])->deleted($event, $config, $this->connection)) {
+        if (!$this->dbDriverFactory->create($config['driver'])->deleted($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not delete database {$config['database']}, the statement failed.");
         }
 
@@ -175,7 +175,7 @@ class DatabaseGenerator
             new Events\Database\Renaming($config, $event->website)
         );
 
-        if (!$this->databaseDriverFactory->create($config['driver'])->updated($event, $config, $this->connection)) {
+        if (!$this->dbDriverFactory->create($config['driver'])->updated($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");
         }
 

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -36,13 +36,20 @@ class DatabaseGenerator
     protected $mode;
 
     /**
+     * @var DatabaseDriverFactory
+     */
+    protected $databaseDriverFactory;
+
+    /**
      * DatabaseGenerator constructor.
      * @param Connection $connection
+     * @param DatabaseDriverFactory $databaseDriverFactory
      */
-    public function __construct(Connection $connection)
+    public function __construct(Connection $connection, DatabaseDriverFactory $databaseDriverFactory)
     {
         $this->connection = $connection;
         $this->mode = config('tenancy.db.tenant-division-mode');
+        $this->databaseDriverFactory = $databaseDriverFactory;
     }
 
     /**
@@ -80,7 +87,7 @@ class DatabaseGenerator
             new Events\Database\Creating($config, $event->website)
         );
 
-        if (!app(DatabaseDriverFactory::class)->create($config['driver'])->created($event, $config, $this->connection)) {
+        if (!$this->databaseDriverFactory->create($config['driver'])->created($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not generate database {$config['database']}, one of the statements failed.");
         }
 
@@ -128,7 +135,7 @@ class DatabaseGenerator
             new Events\Database\Deleting($config, $event->website)
         );
 
-        if (!app(DatabaseDriverFactory::class)->create($config['driver'])->deleted($event, $config, $this->connection)) {
+        if (!$this->databaseDriverFactory->create($config['driver'])->deleted($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not delete database {$config['database']}, the statement failed.");
         }
 
@@ -168,7 +175,7 @@ class DatabaseGenerator
             new Events\Database\Renaming($config, $event->website)
         );
 
-        if (!app(DatabaseDriverFactory::class)->create($config['driver'])->updated($event, $config, $this->connection)) {
+        if (!$this->databaseDriverFactory->create($config['driver'])->updated($event, $config, $this->connection)) {
             throw new GeneratorFailedException("Could not rename database {$config['database']}, the statement failed.");
         }
 

--- a/src/Providers/TenancyProvider.php
+++ b/src/Providers/TenancyProvider.php
@@ -88,6 +88,7 @@ class TenancyProvider extends ServiceProvider
         $this->app->register(Providers\BusProvider::class);
         $this->app->register(Providers\FilesystemProvider::class);
         $this->app->register(Providers\HostnameProvider::class);
+        $this->app->register(Providers\DatabaseDriverProvider::class);
 
         // Register last.
         $this->app->register(Providers\EventProvider::class);

--- a/src/Providers/Tenants/DatabaseDriverProvider.php
+++ b/src/Providers/Tenants/DatabaseDriverProvider.php
@@ -15,11 +15,11 @@
 namespace Hyn\Tenancy\Providers\Tenants;
 
 use Hyn\Tenancy\Database\Connection;
+use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
 use Hyn\Tenancy\Generators\Webserver\Database\Drivers\MariaDB;
 use Hyn\Tenancy\Generators\Webserver\Database\Drivers\PostgreSQL;
 use Hyn\Tenancy\Generators\Webserver\Database\Drivers\PostgresSchema;
 use Illuminate\Support\ServiceProvider;
-use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
 
 class DatabaseDriverProvider extends ServiceProvider
 {

--- a/src/Providers/Tenants/DatabaseDriverProvider.php
+++ b/src/Providers/Tenants/DatabaseDriverProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Providers\Tenants;
+
+use Hyn\Tenancy\Database\Connection;
+use Hyn\Tenancy\Generators\Webserver\Database\Drivers\MariaDB;
+use Hyn\Tenancy\Generators\Webserver\Database\Drivers\PostgreSQL;
+use Hyn\Tenancy\Generators\Webserver\Database\Drivers\PostgresSchema;
+use Illuminate\Support\ServiceProvider;
+use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
+
+class DatabaseDriverProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton('tenancy.db.drivers', function () {
+            return collect($this->drivers());
+        });
+        
+        $this->app->singleton(DatabaseDriverFactory::class);
+    }
+
+    private function drivers()
+    {
+        $isPgsqlSchema = config('tenancy.db.tenant-division-mode') === Connection::DIVISION_MODE_SEPARATE_SCHEMA;
+        
+        return [
+            'pgsql' => $isPgsqlSchema ? PostgresSchema::class : PostgreSQL::class,
+            'mysql' => MariaDB::class,
+        ];
+    }
+}

--- a/tests/extend/DatabaseDriverExtend.php
+++ b/tests/extend/DatabaseDriverExtend.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Tests\Extend;
+
+use Hyn\Tenancy\Events\Websites\Created;
+use Hyn\Tenancy\Events\Websites\Deleted;
+use Hyn\Tenancy\Events\Websites\Updated;
+use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
+use Hyn\Tenancy\Database\Connection;
+
+class DatabaseDriverExtend implements DatabaseGenerator
+{
+    public function created(Created $event, array $config, Connection $connection): bool
+    {
+        return true;
+    }
+
+    public function updated(Updated $event, array $config, Connection $connection): bool
+    {
+        return true;
+    }
+
+    public function deleted(Deleted $event, array $config, Connection $connection): bool
+    {
+        return true;
+    }
+}

--- a/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
+++ b/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
@@ -14,14 +14,10 @@
 
 namespace Hyn\Tenancy\Tests\Generators\Webserver\Database;
 
-use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
-use Hyn\Tenancy\Database\Connection;
-use Hyn\Tenancy\Events\Websites\Created;
-use Hyn\Tenancy\Events\Websites\Deleted;
-use Hyn\Tenancy\Events\Websites\Updated;
 use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
 use Hyn\Tenancy\Generators\Webserver\Database\Drivers\MariaDB;
 use Hyn\Tenancy\Tests\Test;
+use Hyn\Tenancy\Tests\Extend\DatabaseDriverExtend;
 
 class DatabaseDriverFactoryTest extends Test
 {
@@ -60,26 +56,8 @@ class DatabaseDriverFactoryTest extends Test
      */
     public function allows_to_create_custom_driver()
     {
-        app('tenancy.db.drivers')->put('custom', CustomDriver::class);
+        app('tenancy.db.drivers')->put('custom', DatabaseDriverExtend::class);
 
-        $this->assertInstanceOf(CustomDriver::class, (new DatabaseDriverFactory())->create('custom'));
-    }
-}
-
-class CustomDriver implements DatabaseGenerator
-{
-    public function created(Created $event, array $config, Connection $connection): bool
-    {
-        return true;
-    }
-
-    public function updated(Updated $event, array $config, Connection $connection): bool
-    {
-        return true;
-    }
-
-    public function deleted(Deleted $event, array $config, Connection $connection): bool
-    {
-        return true;
+        $this->assertInstanceOf(DatabaseDriverExtend::class, (new DatabaseDriverFactory())->create('custom'));
     }
 }

--- a/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
+++ b/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
@@ -46,6 +46,17 @@ class DatabaseDriverFactoryTest extends Test
 
     /**
      * @test
+     * @expectedException \TypeError
+     */
+    public function throws_an_exception_if_driver_doesnt_implement_contract()
+    {
+        app('tenancy.db.drivers')->put('random', \stdClass::class);
+
+        (new DatabaseDriverFactory())->create('random');
+    }
+
+    /**
+     * @test
      */
     public function allows_to_create_custom_driver()
     {

--- a/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
+++ b/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
@@ -14,14 +14,14 @@
 
 namespace Hyn\Tenancy\Tests\Generators\Webserver\Database;
 
-use Hyn\Tenancy\Tests\Test;
-use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
-use Hyn\Tenancy\Generators\Webserver\Database\Drivers\MariaDB;
 use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
 use Hyn\Tenancy\Database\Connection;
 use Hyn\Tenancy\Events\Websites\Created;
 use Hyn\Tenancy\Events\Websites\Deleted;
 use Hyn\Tenancy\Events\Websites\Updated;
+use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
+use Hyn\Tenancy\Generators\Webserver\Database\Drivers\MariaDB;
+use Hyn\Tenancy\Tests\Test;
 
 class DatabaseDriverFactoryTest extends Test
 {

--- a/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
+++ b/tests/unit-tests/Generators/Webserver/Database/DatabaseDriverFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Tests\Generators\Webserver\Database;
+
+use Hyn\Tenancy\Tests\Test;
+use Hyn\Tenancy\Generators\Webserver\Database\DatabaseDriverFactory;
+use Hyn\Tenancy\Generators\Webserver\Database\Drivers\MariaDB;
+use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
+use Hyn\Tenancy\Database\Connection;
+use Hyn\Tenancy\Events\Websites\Created;
+use Hyn\Tenancy\Events\Websites\Deleted;
+use Hyn\Tenancy\Events\Websites\Updated;
+
+class DatabaseDriverFactoryTest extends Test
+{
+    /**
+     * @test
+     */
+    public function creates_mysql_driver_by_default()
+    {
+        $driver = (new DatabaseDriverFactory())->create();
+
+        $this->assertInstanceOf(MariaDB::class, $driver);
+    }
+
+    /**
+     * @test
+     * @expectedException \Hyn\Tenancy\Exceptions\GeneratorFailedException
+     */
+    public function throws_an_exception_if_driver_doesnt_exist()
+    {
+        (new DatabaseDriverFactory())->create('non-existing-driver');
+    }
+
+    /**
+     * @test
+     */
+    public function allows_to_create_custom_driver()
+    {
+        app('tenancy.db.drivers')->put('custom', CustomDriver::class);
+
+        $this->assertInstanceOf(CustomDriver::class, (new DatabaseDriverFactory())->create('custom'));
+    }
+}
+
+class CustomDriver implements DatabaseGenerator
+{
+    public function created(Created $event, array $config, Connection $connection): bool
+    {
+        return true;
+    }
+
+    public function updated(Updated $event, array $config, Connection $connection): bool
+    {
+        return true;
+    }
+
+    public function deleted(Deleted $event, array $config, Connection $connection): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR adds ability to add your own database drivers.

**Use case:**

This was the single problem I encountered when tried to use SQLite database for tests. 

I can now use SQLite in-memory databases for my tests by simply adding `app('tenancy.db.drivers')->put('sqlite', \Tests\Support\SqliteDriver::class);` to `setUp` method and creating custom SQLite driver:

```php
class SqliteDriver implements DatabaseGenerator
{
    public function created(Created $event, array $config, Connection $connection): bool
    {
        return true;
    }
    
    public function updated(Updated $event, array $config, Connection $connection): bool
    {
        return true;
    }
    
    public function deleted(Deleted $event, array $config, Connection $connection): bool
    {
        return true;
    }
}
```