### PR TITLE
Changed $exitCodes to a reference

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -73,7 +73,7 @@ class RunCommand extends Command
 
         $exitCodes = [];
 
-        $query->chunk(50, function ($websites) use ($environment, $options, $exitCodes) {
+        $query->chunk(50, function ($websites) use ($environment, $options, &$exitCodes) {
             foreach ($websites as $website) {
                 $environment->tenant($website);
 


### PR DESCRIPTION
Without this it always says `Command was executed on zero tenants.`