### PR TITLE
Adding regex validation to HostnameValidator.

### DIFF
--- a/src/Validators/HostnameValidator.php
+++ b/src/Validators/HostnameValidator.php
@@ -19,7 +19,7 @@ use Hyn\Tenancy\Abstracts\Validator;
 class HostnameValidator extends Validator
 {
     protected $create = [
-        'fqdn' => ['required', 'string', 'unique:%system%.%hostnames%,fqdn'],
+        'fqdn' => ['required', 'string', 'unique:%system%.%hostnames%,fqdn', 'regex:/^(?:(?:\*|(?!-)(?:xn--)?[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1})\.)(?:(?!-)(?:xn--)?[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.)*(?!-)(?:xn--)?(?:[a-zA-Z0-9\-]{1,50}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,})$/i'],
         'redirect_to' => ['nullable', 'string', 'url'],
         'force_https' => ['boolean'],
         'under_maintenance_since' => ['nullable', 'date'],
@@ -28,7 +28,7 @@ class HostnameValidator extends Validator
 
     protected $update = [
         'id' => ['required', 'integer'],
-        'fqdn' => ['required', 'string', 'unique:%system%.%hostnames%,fqdn,%id%'],
+        'fqdn' => ['required', 'string', 'unique:%system%.%hostnames%,fqdn,%id%', 'regex:/^(?:(?:\*|(?!-)(?:xn--)?[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1})\.)(?:(?!-)(?:xn--)?[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.)*(?!-)(?:xn--)?(?:[a-zA-Z0-9\-]{1,50}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,})$/i'],
         'redirect_to' => ['nullable', 'string', 'url'],
         'force_https' => ['boolean'],
         'under_maintenance_since' => ['nullable', 'date'],


### PR DESCRIPTION
Also supports wildcard ('*') as subdomain (i.e. `*.example.com`)

Fixes #251
Fixes #377 

Tested with https://regex101.com/

Regex (with `igm` flags):
```
^(?:(?:\*|(?!-)(?:xn--)?[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1})\.)(?:(?!-)(?:xn--)?[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.)*(?!-)(?:xn--)?(?:[a-zA-Z0-9\-]{1,50}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,})$
```

Test cases:
```
# MATCH
xn-fsqu00a.xn-0zwm56d
xn-fsqu00a.xn--vermgensberatung-pwb
xn--stackoverflow.com
stackoverflow.xn--com
stackoverflow.co.uk
google.com.au
i.oh1.me
wow.british-library.uk
xn--stackoverflow.com
stackoverflow.xn--com
stackoverflow.co.uk
0-0O_.COM
a.net
0-0O.COM
0-OZ.CO.uk
0-TENSION.COM.br
0-WH-AO14-0.COM-com.net
a-1234567890-1234567890-1234567890-1234567890-1234567890-1234-z.eu.us
subA.subB.subC.example.com
*.subA.subB.example.com

# NO MATCH
-0-0O.COM
0-0O.-COM
-a.dot
a-1234567890-1234567890-1234567890-1234567890-1234567890-12345-z.eu.us
```