### PR TITLE
Purge database connection only when migrating or seeding multiple tenants

### DIFF
--- a/src/Database/Console/Migrations/FreshCommand.php
+++ b/src/Database/Console/Migrations/FreshCommand.php
@@ -35,8 +35,6 @@ class FreshCommand extends BaseCommand
         $this->input->setOption('database', $this->connection->tenantName());
 
         $this->processHandle(function (Website $website) {
-            $this->connection->set($website);
-
             $this->dropAllTables(
                 $database = $this->connection->tenantName()
             );
@@ -57,8 +55,6 @@ class FreshCommand extends BaseCommand
                     '--force' => 1,
                 ]);
             }
-
-            $this->connection->purge();
         });
     }
 

--- a/src/Traits/AddWebsiteFilterOnCommand.php
+++ b/src/Traits/AddWebsiteFilterOnCommand.php
@@ -29,7 +29,13 @@ trait AddWebsiteFilterOnCommand
 
         $query->orderBy('id')->chunk(10, function (Collection $websites) use ($callable) {
             $websites->each(function ($website) use ($callable, $websites) {
-                $callable($website, $websites);
+                $this->connection->set($website);
+
+                $callable($website);
+
+                if ($websites->count() > 1) {
+                    $this->connection->purge();
+                }
             });
         });
     }

--- a/src/Traits/AddWebsiteFilterOnCommand.php
+++ b/src/Traits/AddWebsiteFilterOnCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 trait AddWebsiteFilterOnCommand
 {
-    protected function processHandle($callable)
+    protected function processHandle($callable = null)
     {
         $query = $this->websites->query();
 
@@ -31,7 +31,7 @@ trait AddWebsiteFilterOnCommand
             $websites->each(function ($website) use ($callable, $websites) {
                 $this->connection->set($website);
 
-                $callable($website);
+                is_callable($callable) ? $callable($website) : parent::handle();
 
                 if ($websites->count() > 1) {
                     $this->connection->purge();

--- a/src/Traits/AddWebsiteFilterOnCommand.php
+++ b/src/Traits/AddWebsiteFilterOnCommand.php
@@ -28,7 +28,9 @@ trait AddWebsiteFilterOnCommand
         }
 
         $query->orderBy('id')->chunk(10, function (Collection $websites) use ($callable) {
-            $websites->each($callable);
+            $websites->each(function ($website) use ($callable, $websites) {
+                $callable($website, $websites);
+            });
         });
     }
 

--- a/src/Traits/MutatesMigrationCommands.php
+++ b/src/Traits/MutatesMigrationCommands.php
@@ -18,7 +18,6 @@ use Hyn\Tenancy\Contracts\Repositories\WebsiteRepository;
 use Hyn\Tenancy\Database\Connection;
 use Illuminate\Database\Migrations\Migrator;
 use InvalidArgumentException;
-use Hyn\Tenancy\Models\Website;
 
 trait MutatesMigrationCommands
 {
@@ -52,9 +51,7 @@ trait MutatesMigrationCommands
         $this->input->setOption('force', true);
         $this->input->setOption('database', $this->connection->tenantName());
 
-        $this->processHandle(function (Website $website) {
-            parent::handle();
-        });
+        $this->processHandle();
     }
 
     /**

--- a/src/Traits/MutatesMigrationCommands.php
+++ b/src/Traits/MutatesMigrationCommands.php
@@ -18,7 +18,6 @@ use Hyn\Tenancy\Contracts\Repositories\WebsiteRepository;
 use Hyn\Tenancy\Database\Connection;
 use Illuminate\Database\Migrations\Migrator;
 use InvalidArgumentException;
-use Illuminate\Support\Collection;
 use Hyn\Tenancy\Models\Website;
 
 trait MutatesMigrationCommands
@@ -53,14 +52,8 @@ trait MutatesMigrationCommands
         $this->input->setOption('force', true);
         $this->input->setOption('database', $this->connection->tenantName());
 
-        $this->processHandle(function (Website $website, Collection $websites) {
-            $this->connection->set($website);
-
+        $this->processHandle(function (Website $website) {
             parent::handle();
-
-            if ($websites->count() > 1) {
-                $this->connection->purge();
-            }
         });
     }
 

--- a/src/Traits/MutatesMigrationCommands.php
+++ b/src/Traits/MutatesMigrationCommands.php
@@ -18,6 +18,8 @@ use Hyn\Tenancy\Contracts\Repositories\WebsiteRepository;
 use Hyn\Tenancy\Database\Connection;
 use Illuminate\Database\Migrations\Migrator;
 use InvalidArgumentException;
+use Illuminate\Support\Collection;
+use Hyn\Tenancy\Models\Website;
 
 trait MutatesMigrationCommands
 {
@@ -51,12 +53,14 @@ trait MutatesMigrationCommands
         $this->input->setOption('force', true);
         $this->input->setOption('database', $this->connection->tenantName());
 
-        $this->processHandle(function ($website) {
+        $this->processHandle(function (Website $website, Collection $websites) {
             $this->connection->set($website);
 
             parent::handle();
 
-            $this->connection->purge();
+            if ($websites->count() > 1) {
+                $this->connection->purge();
+            }
         });
     }
 

--- a/src/Traits/MutatesSeedCommands.php
+++ b/src/Traits/MutatesSeedCommands.php
@@ -18,7 +18,6 @@ use Hyn\Tenancy\Contracts\Repositories\WebsiteRepository;
 use Hyn\Tenancy\Database\Connection;
 use Hyn\Tenancy\Contracts\Website;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Illuminate\Support\Collection;
 
 trait MutatesSeedCommands
 {
@@ -52,14 +51,8 @@ trait MutatesSeedCommands
         $this->input->setOption('force', true);
         $this->input->setOption('database', $this->connection->tenantName());
 
-        $this->processHandle(function (Website $website, Collection $websites) {
-            $this->connection->set($website);
-
+        $this->processHandle(function (Website $website) {
             parent::handle();
-
-            if ($websites->count() > 1) {
-                $this->connection->purge();
-            }
         });
     }
 

--- a/src/Traits/MutatesSeedCommands.php
+++ b/src/Traits/MutatesSeedCommands.php
@@ -16,7 +16,6 @@ namespace Hyn\Tenancy\Traits;
 
 use Hyn\Tenancy\Contracts\Repositories\WebsiteRepository;
 use Hyn\Tenancy\Database\Connection;
-use Hyn\Tenancy\Contracts\Website;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 trait MutatesSeedCommands
@@ -51,9 +50,7 @@ trait MutatesSeedCommands
         $this->input->setOption('force', true);
         $this->input->setOption('database', $this->connection->tenantName());
 
-        $this->processHandle(function (Website $website) {
-            parent::handle();
-        });
+        $this->processHandle();
     }
 
     /**

--- a/src/Traits/MutatesSeedCommands.php
+++ b/src/Traits/MutatesSeedCommands.php
@@ -18,6 +18,7 @@ use Hyn\Tenancy\Contracts\Repositories\WebsiteRepository;
 use Hyn\Tenancy\Database\Connection;
 use Hyn\Tenancy\Contracts\Website;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Support\Collection;
 
 trait MutatesSeedCommands
 {
@@ -51,12 +52,14 @@ trait MutatesSeedCommands
         $this->input->setOption('force', true);
         $this->input->setOption('database', $this->connection->tenantName());
 
-        $this->processHandle(function (Website $website) {
+        $this->processHandle(function (Website $website, Collection $websites) {
             $this->connection->set($website);
 
             parent::handle();
 
-            $this->connection->purge();
+            if ($websites->count() > 1) {
+                $this->connection->purge();
+            }
         });
     }
 

--- a/tests/traits/InteractsWithMigrations.php
+++ b/tests/traits/InteractsWithMigrations.php
@@ -17,8 +17,10 @@ namespace Hyn\Tenancy\Tests\Traits;
 use Hyn\Tenancy\Providers\TenancyProvider;
 use Hyn\Tenancy\Providers\Tenants\ConfigurationProvider;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Foundation\Testing\PendingCommand;
 use SampleSeeder;
+use Mockery;
+use Hyn\Tenancy\Database\Connection;
+use Illuminate\Contracts\Console\Kernel;
 
 trait InteractsWithMigrations
 {
@@ -96,5 +98,22 @@ trait InteractsWithMigrations
                 $websites->each($callback);
             });
         }
+    }
+
+    protected function swapConnectionWithSpy()
+    {
+        $spy = Mockery::spy($this->app[Connection::class]);
+
+        $this->app[Connection::class] = $spy;
+
+        return $spy;
+    }
+
+    protected function reloadArtisanCommand($command)
+    {
+        $this->app->forgetInstance($command);
+
+        $kernel = $this->app[Kernel::class];
+        $kernel->registerCommand($this->app[$command]);
     }
 }

--- a/tests/unit-tests/Commands/FreshCommandTest.php
+++ b/tests/unit-tests/Commands/FreshCommandTest.php
@@ -68,8 +68,8 @@ class FreshCommandTest extends DatabaseCommandTest
      */
     public function purges_connection_after_running_fresh_on_multiple_tenants()
     {
-        $websiteB = new Website();
-        $this->websites->create($websiteB);
+        $website = new Website();
+        $this->websites->create($website);
 
         $this->assertEquals(2, $this->websites->query()->count());
 

--- a/tests/unit-tests/Commands/FreshCommandTest.php
+++ b/tests/unit-tests/Commands/FreshCommandTest.php
@@ -63,6 +63,37 @@ class FreshCommandTest extends DatabaseCommandTest
         ]);
     }
 
+    /**
+     * @test
+     */
+    public function purges_connection_after_running_fresh_on_multiple_tenants()
+    {
+        $websiteB = new Website();
+        $this->websites->create($websiteB);
+
+        $this->assertEquals(2, $this->websites->query()->count());
+
+        $connection = $this->swapConnectionWithSpy();
+        $this->reloadArtisanCommand(FreshCommand::class);
+
+        $this->migrateAndTest('migrate:fresh');
+
+        $connection->shouldHaveReceived('purge')->twice();
+    }
+
+    /**
+     * @test
+     */
+    public function does_not_purge_connection_after_running_fresh_on_one_tenant()
+    {
+        $connection = $this->swapConnectionWithSpy();
+        $this->reloadArtisanCommand(FreshCommand::class);
+
+        $this->migrateAndTest('migrate:fresh');
+
+        $connection->shouldNotHaveReceived('purge');
+    }
+
     protected function duringSetUp(Application $app)
     {
         $this->setUpWebsites(true);

--- a/tests/unit-tests/Commands/MigrateCommandTest.php
+++ b/tests/unit-tests/Commands/MigrateCommandTest.php
@@ -90,8 +90,8 @@ class MigrateCommandTest extends DatabaseCommandTest
      */
     public function purges_connection_after_running_migrate_on_multiple_tenants()
     {
-        $websiteB = new Website();
-        $this->websites->create($websiteB);
+        $website = new Website();
+        $this->websites->create($website);
 
         $this->assertEquals(2, $this->websites->query()->count());
 

--- a/tests/unit-tests/Commands/MigrateCommandTest.php
+++ b/tests/unit-tests/Commands/MigrateCommandTest.php
@@ -84,4 +84,35 @@ class MigrateCommandTest extends DatabaseCommandTest
             );
         });
     }
+
+    /**
+     * @test
+     */
+    public function purges_connection_after_running_migrate_on_multiple_tenants()
+    {
+        $websiteB = new Website();
+        $this->websites->create($websiteB);
+
+        $this->assertEquals(2, $this->websites->query()->count());
+
+        $connection = $this->swapConnectionWithSpy();
+        $this->reloadArtisanCommand(MigrateCommand::class);
+
+        $this->migrateAndTest('migrate');
+
+        $connection->shouldHaveReceived('purge')->twice();
+    }
+
+    /**
+     * @test
+     */
+    public function does_not_purge_connection_after_running_migrate_on_one_tenant()
+    {
+        $connection = $this->swapConnectionWithSpy();
+        $this->reloadArtisanCommand(MigrateCommand::class);
+
+        $this->migrateAndTest('migrate');
+
+        $connection->shouldNotHaveReceived('purge');
+    }
 }

--- a/tests/unit-tests/Commands/SeedCommandTest.php
+++ b/tests/unit-tests/Commands/SeedCommandTest.php
@@ -119,8 +119,8 @@ class SeedCommandTest extends DatabaseCommandTest
      */
     public function purges_connection_after_running_seed_on_multiple_tenants()
     {
-        $websiteB = new Website();
-        $this->websites->create($websiteB);
+        $website = new Website();
+        $this->websites->create($website);
 
         $this->assertEquals(2, $this->websites->query()->count());
 

--- a/tests/unit-tests/Commands/SeedCommandTest.php
+++ b/tests/unit-tests/Commands/SeedCommandTest.php
@@ -113,4 +113,39 @@ class SeedCommandTest extends DatabaseCommandTest
             );
         });
     }
+
+    /**
+     * @test
+     */
+    public function purges_connection_after_running_seed_on_multiple_tenants()
+    {
+        $websiteB = new Website();
+        $this->websites->create($websiteB);
+
+        $this->assertEquals(2, $this->websites->query()->count());
+
+        $connection = $this->swapConnectionWithSpy();
+        $this->reloadArtisanCommand(SeedCommand::class);
+
+        $this->migrateAndTest('migrate');
+
+        $this->seedAndTest();
+
+        $connection->shouldHaveReceived('purge')->twice();
+    }
+
+    /**
+     * @test
+     */
+    public function does_not_purge_connection_after_running_seed_on_one_tenant()
+    {
+        $this->migrateAndTest('migrate');
+
+        $connection = $this->swapConnectionWithSpy();
+        $this->reloadArtisanCommand(SeedCommand::class);
+
+        $this->connection->seed($this->website, SampleSeeder::class);
+
+        $connection->shouldNotHaveReceived('purge');
+    }
 }


### PR DESCRIPTION
Current implementation of `tenancy:migrate` and `tenancy:seed` commands purges the database connection no matter of how many tenants are migrated or seeded. It means that it can’t be used with SQLite in-memory databases and that makes testing more complex.

This PR updates `tenancy:migrate` and `tenancy:seed` commands to only purge the database connection when multiple tenants are migrated or seeded, which makes `TenantAwareTestCase` more simple and elegant compared to the older version (https://github.com/hyn/multi-tenant/pull/627#issuecomment-427492644):
```php
class TenantAwareTestCase extends TestCase
{
    use RefreshDatabase;

    protected $hostname = 'test.test.test';

    protected function setUp()
    {
        parent::setUp();

        app('tenancy.db.drivers')->put('sqlite', SqliteDriver::class);

        config(['tenancy.db.tenant-division-mode' => 'bypass']);

        $website = new Website;        
        app(WebsiteRepository::class)->create($website);
        
        $hostname = new Hostname;
        $hostname->fqdn = $this->hostname;
        $hostname = app(HostnameRepository::class)->create($hostname);
        app(HostnameRepository::class)->attach($hostname, $website);
        
        app()->singleton(CurrentHostname::class, function () use ($hostname) {
            return $hostname;
        });

        (new RouteProvider(app()))->boot();
    }
}
```