### PR TITLE
Allow to configure database privileges for the tenant DB user

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -247,6 +247,19 @@ return [
         'auto-create-tenant-database-user' => true,
 
         /**
+         * Set of database privileges to give to the tenant database user.
+         *
+         * @info Useful in case your database restricts the privileges you
+         *       can set (for example AWS RDS).
+         * @info These privileges are only used in case tenant database users
+         *       are set to be created.
+         *
+         * @info null by default means "ALL PRIVILEGES". Override with a list
+         *       of privileges as a string, e.g. 'SELECT, UPDATE'.
+         */
+        'tenant-database-user-privileges' => null,
+
+        /**
          * Automatically rename the tenant database when the random id of the
          * website changes. This should not be too common, but in case it happens
          * we automatically want to move databases accordingly.

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -49,10 +49,7 @@ class MariaDB implements DatabaseGenerator
         };
         $grant = function ($connection) use ($config, $createUser) {
             if ($createUser) {
-                $privileges = config('tenancy.db.tenant-database-user-privileges', null);
-                if (!is_string($privileges)) {
-                    $privileges = 'ALL';
-                }
+                $privileges = config('tenancy.db.tenant-database-user-privileges', 'ALL');
                 return $connection->statement("GRANT $privileges ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
             }
 

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -49,7 +49,11 @@ class MariaDB implements DatabaseGenerator
         };
         $grant = function ($connection) use ($config, $createUser) {
             if ($createUser) {
-                return $connection->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
+                $privileges = config('tenancy.db.tenant-database-user-privileges', null);
+                if (!is_string($privileges)) {
+                    $privileges = 'ALL';
+                }
+                return $connection->statement("GRANT $privileges ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
             }
 
             return true;

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -49,7 +49,7 @@ class MariaDB implements DatabaseGenerator
         };
         $grant = function ($connection) use ($config, $createUser) {
             if ($createUser) {
-                $privileges = config('tenancy.db.tenant-database-user-privileges', 'ALL');
+                $privileges = config('tenancy.db.tenant-database-user-privileges', null) ?? 'ALL';
                 return $connection->statement("GRANT $privileges ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
             }
 

--- a/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
@@ -29,7 +29,7 @@ class PostgresSchema extends PostgreSQL
 
     protected function grantPrivileges(IlluminateConnection $connection, array $config)
     {
-        $privileges = config('tenancy.db.tenant-database-user-privileges', 'ALL PRIVILEGES');
+        $privileges = config('tenancy.db.tenant-database-user-privileges', null) ?? 'ALL PRIVILEGES';
 
         return $connection->statement("GRANT $privileges ON SCHEMA \"{$config['schema']}\" TO \"{$config['username']}\"");
     }

--- a/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
@@ -29,7 +29,12 @@ class PostgresSchema extends PostgreSQL
 
     protected function grantPrivileges(IlluminateConnection $connection, array $config)
     {
-        return $connection->statement("GRANT ALL PRIVILEGES ON SCHEMA \"{$config['schema']}\" TO \"{$config['username']}\"");
+        $privileges = config('tenancy.db.tenant-database-user-privileges', null);
+        if (!is_string($privileges)) {
+            $privileges = 'ALL PRIVILEGES';
+        }
+
+        return $connection->statement("GRANT $privileges ON SCHEMA \"{$config['schema']}\" TO \"{$config['username']}\"");
     }
 
     /**

--- a/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgresSchema.php
@@ -29,10 +29,7 @@ class PostgresSchema extends PostgreSQL
 
     protected function grantPrivileges(IlluminateConnection $connection, array $config)
     {
-        $privileges = config('tenancy.db.tenant-database-user-privileges', null);
-        if (!is_string($privileges)) {
-            $privileges = 'ALL PRIVILEGES';
-        }
+        $privileges = config('tenancy.db.tenant-database-user-privileges', 'ALL PRIVILEGES');
 
         return $connection->statement("GRANT $privileges ON SCHEMA \"{$config['schema']}\" TO \"{$config['username']}\"");
     }


### PR DESCRIPTION
Fix #660, alternative to #663

Some databases like RDS do not allow granting all privileges. This new configuration option will let user provide a custom privilege list.