### PR TITLE
Tweak repositories to cache null values as string

### DIFF
--- a/src/Repositories/HostnameRepository.php
+++ b/src/Repositories/HostnameRepository.php
@@ -62,10 +62,10 @@ class HostnameRepository implements Contract
     public function findByHostname(string $hostname)
     {
         $model = $this->cache->remember("tenancy.hostname.$hostname", config('tenancy.hostname.cache'), function () use ($hostname) {
-            return $this->hostname->newQuery()->where('fqdn', $hostname)->first() ?? 'null';
+            return $this->hostname->newQuery()->where('fqdn', $hostname)->first() ?? 'none';
         });
 
-        return $model === 'null' ? null : $model;
+        return $model === 'none' ? null : $model;
     }
 
     /**

--- a/src/Repositories/HostnameRepository.php
+++ b/src/Repositories/HostnameRepository.php
@@ -61,9 +61,11 @@ class HostnameRepository implements Contract
      */
     public function findByHostname(string $hostname)
     {
-        return $this->cache->remember("tenancy.hostname.$hostname", config('tenancy.hostname.cache'), function () use ($hostname) {
-            return $this->hostname->newQuery()->where('fqdn', $hostname)->first();
+        $model = $this->cache->remember("tenancy.hostname.$hostname", config('tenancy.hostname.cache'), function () use ($hostname) {
+            return $this->hostname->newQuery()->where('fqdn', $hostname)->first() ?? 'null';
         });
+
+        return $model === 'null' ? null : $model;
     }
 
     /**

--- a/src/Repositories/WebsiteRepository.php
+++ b/src/Repositories/WebsiteRepository.php
@@ -57,9 +57,11 @@ class WebsiteRepository implements Contract
      */
     public function findByUuid(string $uuid)
     {
-        return $this->cache->remember("tenancy.website.$uuid", config('tenancy.website.cache'), function () use ($uuid) {
-            return $this->query()->where('uuid', $uuid)->first();
+        $model = $this->cache->remember("tenancy.website.$uuid", config('tenancy.website.cache'), function () use ($uuid) {
+            return $this->query()->where('uuid', $uuid)->first() ?? 'null';
         });
+
+        return $model === 'null' ? null : $model;
     }
 
     /**

--- a/src/Repositories/WebsiteRepository.php
+++ b/src/Repositories/WebsiteRepository.php
@@ -58,10 +58,10 @@ class WebsiteRepository implements Contract
     public function findByUuid(string $uuid)
     {
         $model = $this->cache->remember("tenancy.website.$uuid", config('tenancy.website.cache'), function () use ($uuid) {
-            return $this->query()->where('uuid', $uuid)->first() ?? 'null';
+            return $this->query()->where('uuid', $uuid)->first() ?? 'none';
         });
 
-        return $model === 'null' ? null : $model;
+        return $model === 'none' ? null : $model;
     }
 
     /**


### PR DESCRIPTION
Fixes #637 

Because of Laravel cache `remember` method, null values are not retrieved from cache but callback is runned every time.

Storing `null` as `'null'` fixes this and prevent database queries to be run a lot of time if hostname or website is not found in database