### PR TITLE
Add support for division mode to separate database with shared credentials as system

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -45,6 +45,11 @@ class Connection
     const DIVISION_MODE_SEPARATE_PREFIX = 'prefix';
 
     /**
+     * Allows multiple database but with same user access
+     */
+    const DIVISION_MODE_SEPARATE_SHARED_ACCESS = 'shared';
+
+    /**
      * Allows division by schema. Postges only.
      */
     const DIVISION_MODE_SEPARATE_SCHEMA = 'schema';
@@ -319,6 +324,11 @@ class Connection
                 break;
             case static::DIVISION_MODE_SEPARATE_PREFIX:
                 $clone['prefix'] = sprintf('%d_', $website->id);
+                break;
+            case static::DIVISION_MODE_SEPARATE_SHARED_ACCESS:
+                $clone['database'] = $website->uuid;
+                $clone['username'] = config('database.connections.system.username');
+                $clone['password'] = config('database.connections.system.password');
                 break;
             case static::DIVISION_MODE_SEPARATE_SCHEMA:
                 $clone['username'] = $clone['schema'] = $website->uuid;

--- a/src/Generators/Webserver/Database/DatabaseGenerator.php
+++ b/src/Generators/Webserver/Database/DatabaseGenerator.php
@@ -74,6 +74,7 @@ class DatabaseGenerator
 
         if (!in_array($this->mode, [
             Connection::DIVISION_MODE_SEPARATE_DATABASE,
+            Connection::DIVISION_MODE_SEPARATE_SHARED_ACCESS,
             Connection::DIVISION_MODE_SEPARATE_SCHEMA,
         ])) {
             return;
@@ -122,6 +123,7 @@ class DatabaseGenerator
 
         if (!in_array($this->mode, [
             Connection::DIVISION_MODE_SEPARATE_DATABASE,
+            Connection::DIVISION_MODE_SEPARATE_SHARED_ACCESS,
             Connection::DIVISION_MODE_SEPARATE_SCHEMA,
         ])) {
             return;
@@ -156,6 +158,7 @@ class DatabaseGenerator
 
         if (!in_array($this->mode, [
             Connection::DIVISION_MODE_SEPARATE_DATABASE,
+            Connection::DIVISION_MODE_SEPARATE_SHARED_ACCESS,
             Connection::DIVISION_MODE_SEPARATE_SCHEMA,
         ])) {
             return;


### PR DESCRIPTION
This PR adds ability to use new tenant division mode: `DIVISION_MODE_SEPARATE_SHARED_ACCESS` / `shared`

Use case:

I usually manage / monitor database using DBeaver, that shows all databases regardless of privileges for the user I was logged to.

However, in RDS setup, `rds_superuser` role  is not really a superuser, it discourages user to switch access to another database / `use other_database` and doing query, instead must create new/edit connection and login with different credentials.
Which is still not allowed after #665 addition.

In my case, tenant's user will not be given access to database directly.

Thanks.