### PR TITLE
Improving migration running & adding config. option for setting database user host

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -301,7 +301,7 @@ return [
          * Define the host permission (used only by MySQL/MariaDB) to enable the connection from remote
          * machines
          */
-        'user-host-permission' => env('TENANCY_DATABASE_USER_HOST_PERMISSION', '127.0.0.1'),
+        'tenant-database-user-host-permission' => env('TENANCY_DATABASE_USER_HOST_PERMISSION', '127.0.0.1'),
     ],
 
     /**

--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -283,6 +283,12 @@ return [
         'force-system-connection-of-models' => [
 //            App\User::class
         ],
+
+        /**
+         * Define the host permission (used only by MySQL/MariaDB) to enable the connection from remote
+         * machines
+         */
+        'user-host-permission' => env('TENANCY_DATABASE_USER_HOST_PERMISSION', '127.0.0.1'),
     ],
 
     /**

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -37,6 +37,7 @@ class MariaDB implements DatabaseGenerator
 
         $user = function ($connection) use ($config, $createUser) {
             if ($createUser) {
+                $config['host'] = config('tenancy.db.user-host-permission');
                 return $connection->statement("CREATE USER IF NOT EXISTS `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'");
             }
 
@@ -49,6 +50,7 @@ class MariaDB implements DatabaseGenerator
         };
         $grant = function ($connection) use ($config, $createUser) {
             if ($createUser) {
+                $config['host'] = config('tenancy.db.user-host-permission');
                 return $connection->statement("GRANT ALL ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
             }
 

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -37,7 +37,7 @@ class MariaDB implements DatabaseGenerator
 
         $user = function ($connection) use ($config, $createUser) {
             if ($createUser) {
-                $config['host'] = config('tenancy.db.user-host-permission');
+                $config['host'] = config('tenancy.db.tenant-database-user-host-permission');
                 return $connection->statement("CREATE USER IF NOT EXISTS `{$config['username']}`@'{$config['host']}' IDENTIFIED BY '{$config['password']}'");
             }
 
@@ -50,7 +50,7 @@ class MariaDB implements DatabaseGenerator
         };
         $grant = function ($connection) use ($config, $createUser) {
             if ($createUser) {
-                $config['host'] = config('tenancy.db.user-host-permission');
+                $config['host'] = config('tenancy.db.tenant-database-user-host-permission');
                 $privileges = config('tenancy.db.tenant-database-user-privileges', null) ?? 'ALL';
                 return $connection->statement("GRANT $privileges ON `{$config['database']}`.* TO `{$config['username']}`@'{$config['host']}'");
             }

--- a/src/Listeners/Database/MigratesTenants.php
+++ b/src/Listeners/Database/MigratesTenants.php
@@ -47,7 +47,7 @@ class MigratesTenants
      */
     public function migrate(WebsiteEvent $event): bool
     {
-        $paths = $this->getMigrationPaths();
+        $paths = $this->connection->getMigrationPaths();
 
         foreach ($paths as $path) {
             if ($path && realpath($path) && $this->connection->migrate($event->website, $path)) {
@@ -56,14 +56,5 @@ class MigratesTenants
         }
 
         return true;
-    }
-
-    protected function getMigrationPaths()
-    {
-        if (($path = config('tenancy.db.tenant-migrations-path')) && ! empty($path)) {
-            return (array) $path;
-        }
-
-        return [];
     }
 }

--- a/src/Traits/MutatesMigrationCommands.php
+++ b/src/Traits/MutatesMigrationCommands.php
@@ -71,9 +71,10 @@ trait MutatesMigrationCommands
             return parent::getMigrationPaths();
         }
 
-        // Tenant migrations path is configured.
-        if (($path = config('tenancy.db.tenant-migrations-path')) && ! empty($path)) {
-            return (array) $path;
+        $paths = $this->connection->getMigrationPaths();
+
+        if (count($paths) > 0) {
+            return $paths;
         }
 
         throw new InvalidArgumentException("To prevent unwanted migrations from database/migrations, always specify a path.");


### PR DESCRIPTION
Hi!

First of all, thanks for such a great package. I made a few changes that I believe that may be useful for somebody out there. They are:

- I changed the way we run the `tenant:migrate`, because when I specify an array of migration paths, essentially I want them to run accordingly with their migration base names (the date of creation of the migration - we do not want to run into out-of-sequence-migration-running). The only problem is that I had to make [a little change into the Laravel´s migrator](https://github.com/laravel/framework/compare/5.7...the-mr-tech:5.7#diff-a66c98fc0ca13ef8851970c40f8342d1) to accept migration files paths instead of directory paths only (I intend to open a pull request on Laravel´s framework repository too).
- Also, I created a configuration option called `tenancy.db.tenant-database-user-host-permission` to allow specifying a host when creating a new database user for a new site, enabling the multi-tenant to work with databases servers in another machines

That's it