### PR TITLE
abort to default hostname upon non-identification without required tenant

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -121,6 +121,16 @@ return [
          * @warn this must be a FQDN, these have no protocol or path!
          */
         'default' => env('TENANCY_DEFAULT_HOSTNAME'),
+        
+        /**
+         * If you want the multi tenant application to fall back to a fallback
+         * url, without requiring it to be an actual tenant in the system,
+         * complete in detail the default fallback url with protocol.
+         * 
+         * e.g. https://example.org
+         */
+        'fallback-url' => env('TENANCY_FALLBACK_URL'),
+        
         /**
          * The package is able to identify the requested hostname by itself,
          * disable to get full control (and responsibility) over hostname

--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -69,6 +69,15 @@ class HostnameActions
                 return $this->secure($hostname, $request);
             }
         } else {
+            if (config('tenancy.hostname.default')) {
+                $scheme = optional(request())->getScheme() ?? parse_url(config('app.url', PHP_URL_SCHEME));
+                $url = sprintf('%s://%s', $scheme, config('tenancy.hostname.default'));
+
+                if ($url !== request()->url()) {
+                    return redirect()->away($url);
+                }
+            }
+
             $this->abort($request);
         }
 

--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -69,9 +69,8 @@ class HostnameActions
                 return $this->secure($hostname, $request);
             }
         } else {
-            if (config('tenancy.hostname.default')) {
-                $scheme = optional(request())->getScheme() ?? parse_url(config('app.url', PHP_URL_SCHEME));
-                $url = sprintf('%s://%s', $scheme, config('tenancy.hostname.default'));
+            if (config('tenancy.hostname.fallback-url')) {
+                $url = config('tenancy.hostname.fallback-url');
 
                 if (strstr(request()->url(), $url) == false) {
                     return redirect()->away($url);

--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -73,7 +73,7 @@ class HostnameActions
                 $scheme = optional(request())->getScheme() ?? parse_url(config('app.url', PHP_URL_SCHEME));
                 $url = sprintf('%s://%s', $scheme, config('tenancy.hostname.default'));
 
-                if ($url !== request()->url()) {
+                if (strstr(request()->url(), $url) == false) {
                     return redirect()->away($url);
                 }
             }


### PR DESCRIPTION
The way the package works now is that when a tenant is not identified it will do the following:

1. Check to see if you want to abort upon no identification. If so then simply 404.
2. If you have a fallback, go to that tenant, however you are required to have that tenant setup.

I thought it would be nice to have a full back location without actually needing to have a tenant. Maybe that would be considered the landing page for the SaaS.

Let me know what you guys think.