### PR TITLE
Dropped APP_KEY usage and implemented a way to update tenant users password

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -15,6 +15,12 @@
 use Hyn\Tenancy\Database\Connection;
 
 return [
+
+	/**
+	 * Random key used for tenant database user password
+	 */
+	'key' => env('TENANCY_KEY'),
+
     'models' => [
         /**
          * Specify different models to be used for the global, system database

--- a/src/Commands/UpdateKeyCommand.php
+++ b/src/Commands/UpdateKeyCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Commands;
+
+use Hyn\Tenancy\Events\KeyUpdated;
+use Hyn\Tenancy\Traits\DispatchesEvents;
+use Illuminate\Console\Command;
+
+class UpdateKeyCommand extends Command
+{
+    use DispatchesEvents;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tenancy:key:update';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update tenant users passwords.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+    	$this->emitEvent(new KeyUpdated());
+    }
+}

--- a/src/Contracts/Webserver/DatabaseGenerator.php
+++ b/src/Contracts/Webserver/DatabaseGenerator.php
@@ -14,6 +14,7 @@
 
 namespace Hyn\Tenancy\Contracts\Webserver;
 
+use Hyn\Tenancy\Contracts\Website;
 use Hyn\Tenancy\Database\Connection;
 use Hyn\Tenancy\Events\Websites\Created;
 use Hyn\Tenancy\Events\Websites\Deleted;
@@ -24,4 +25,5 @@ interface DatabaseGenerator
     public function created(Created $event, array $config, Connection $connection): bool;
     public function updated(Updated $event, array $config, Connection $connection): bool;
     public function deleted(Deleted $event, array $config, Connection $connection): bool;
+    public function updatePassword(Website $website, array $config, Connection $connection): bool;
 }

--- a/src/Events/KeyUpdated.php
+++ b/src/Events/KeyUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://laravel-tenancy.com
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Events;
+
+use Hyn\Tenancy\Abstracts\AbstractEvent;
+
+class KeyUpdated extends AbstractEvent
+{
+}

--- a/src/Generators/Database/DefaultPasswordGenerator.php
+++ b/src/Generators/Database/DefaultPasswordGenerator.php
@@ -37,9 +37,11 @@ class DefaultPasswordGenerator implements PasswordGenerator
     public function generate(Website $website) : string
     {
         return md5(sprintf(
-            '%s.%d',
-            $this->app['config']->get('app.key'),
-            $website->id
+			'%d.%s.%s.%s',
+			$website->id,
+			$website->uuid,
+			$website->created_at,
+            $this->app['config']->get('tenancy.key')
         ));
     }
 }

--- a/src/Generators/Webserver/Database/Drivers/MariaDB.php
+++ b/src/Generators/Webserver/Database/Drivers/MariaDB.php
@@ -15,6 +15,7 @@
 namespace Hyn\Tenancy\Generators\Webserver\Database\Drivers;
 
 use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
+use Hyn\Tenancy\Contracts\Website;
 use Hyn\Tenancy\Database\Connection;
 use Hyn\Tenancy\Events\Websites\Created;
 use Hyn\Tenancy\Events\Websites\Deleted;
@@ -104,4 +105,17 @@ class MariaDB implements DatabaseGenerator
             return $delete($connection) && $user($connection);
         });
     }
+
+	public function updatePassword(Website $website, array $config, Connection $connection): bool
+	{
+		$user = function ($connection) use ($config) {
+			$change = $connection->statement("UPDATE mysql.user SET Password=PASSWORD('{$config['password']}') WHERE user='{$config['username']}' AND Host='{$config['host']}'");
+			$connection->statement("FLUSH PRIVILEGES");
+			return $change;
+		};
+
+		return $connection->system($website)->transaction(function (IlluminateConnection $connection) use ($user) {
+			return $user($connection);
+		});
+	}
 }

--- a/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
+++ b/src/Generators/Webserver/Database/Drivers/PostgreSQL.php
@@ -15,6 +15,7 @@
 namespace Hyn\Tenancy\Generators\Webserver\Database\Drivers;
 
 use Hyn\Tenancy\Contracts\Webserver\DatabaseGenerator;
+use Hyn\Tenancy\Contracts\Website;
 use Hyn\Tenancy\Database\Connection;
 use Hyn\Tenancy\Events\Websites\Created;
 use Hyn\Tenancy\Events\Websites\Deleted;
@@ -149,4 +150,9 @@ class PostgreSQL implements DatabaseGenerator
 
         return true;
     }
+
+	public function updatePassword(Website $website, array $config, Connection $connection): bool
+	{
+		return $connection->system($website)->statement("ALTER USER \"{$config['username']}\" WITH PASSWORD '{$config['password']}'");
+	}
 }

--- a/src/Providers/TenancyProvider.php
+++ b/src/Providers/TenancyProvider.php
@@ -15,8 +15,8 @@
 namespace Hyn\Tenancy\Providers;
 
 use Hyn\Tenancy\Commands\RunCommand;
-use Hyn\Tenancy\Commands\InstallCommand;
 use Hyn\Tenancy\Commands\RecreateCommand;
+use Hyn\Tenancy\Commands\UpdateKeyCommand;
 use Hyn\Tenancy\Contracts;
 use Hyn\Tenancy\Environment;
 use Hyn\Tenancy\Listeners\Database\FlushHostnameCache;
@@ -57,7 +57,7 @@ class TenancyProvider extends ServiceProvider
     {
         $this->bootCommands();
     }
-    
+
     protected function registerModels()
     {
         $config = $this->app['config']['tenancy.models'];
@@ -101,7 +101,8 @@ class TenancyProvider extends ServiceProvider
     {
         $this->commands([
             RecreateCommand::class,
-            RunCommand::class
+            RunCommand::class,
+			UpdateKeyCommand::class,
         ]);
     }
 

--- a/tests/extend/DatabaseDriverExtend.php
+++ b/tests/extend/DatabaseDriverExtend.php
@@ -14,6 +14,7 @@
 
 namespace Hyn\Tenancy\Tests\Extend;
 
+use Hyn\Tenancy\Contracts\Website;
 use Hyn\Tenancy\Events\Websites\Created;
 use Hyn\Tenancy\Events\Websites\Deleted;
 use Hyn\Tenancy\Events\Websites\Updated;
@@ -36,4 +37,9 @@ class DatabaseDriverExtend implements DatabaseGenerator
     {
         return true;
     }
+
+	public function updatePassword(Website $website, array $config, Connection $connection): bool
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
Added new config value `tenancy.key` which is now used for tenant password generation instead of `APP_KEY`.
Added command `tenancy:key:update` to update tenant user password after new tenancy key has been set (and when updating to 5.4).