### PR TITLE
Small Fix: PHPUnit Warning

### DIFF
--- a/tests/unit-tests/Webserver/Vhost/NginxGeneratorTest.php
+++ b/tests/unit-tests/Webserver/Vhost/NginxGeneratorTest.php
@@ -76,6 +76,6 @@ class NginxGeneratorTest extends Test
 
         $config = $this->filesystem->get($path);
 
-        $this->assertContains('alias', $config);
+        $this->assertStringContainsString('alias', $config);
     }
 }


### PR DESCRIPTION
There's a small [PHPUnit Warning](https://circleci.com/gh/hyn/multi-tenant/2992) given on current code, this simply fixes that, it's small, nothing important / breaking.
```
There was 1 warning:
1) Hyn\Tenancy\Tests\Webserver\Vhost\NginxGeneratorTest::generates_vhost_media_alias
Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9.
```