### PR TITLE
Change LoadsViewsTest to match expected values

### DIFF
--- a/tests/unit-tests/Filesystem/LoadsViewsTest.php
+++ b/tests/unit-tests/Filesystem/LoadsViewsTest.php
@@ -61,7 +61,7 @@ class LoadsViewsTest extends Test
 
         $this->assertTrue($this->views->exists('foo'));
 
-        $this->assertEquals('bar', $this->views->make('foo')->render());
+        $this->assertEquals("bar\n", $this->views->make('foo')->render());
     }
 
     /**
@@ -80,7 +80,7 @@ class LoadsViewsTest extends Test
 
         $this->activateTenant();
 
-        $this->assertEquals('bar', $this->views->make('welcome')->render());
+        $this->assertEquals("bar\n", $this->views->make('welcome')->render());
     }
 
     /**
@@ -101,7 +101,7 @@ class LoadsViewsTest extends Test
 
         $this->activateTenant();
 
-        $this->assertNotEquals('bar', $this->views->make('welcome')->render());
+        $this->assertNotEquals("bar\n", $this->views->make('welcome')->render());
     }
 
     /**
@@ -122,7 +122,7 @@ class LoadsViewsTest extends Test
 
         $this->activateTenant();
 
-        $this->assertNotEquals('bar', $this->views->make('welcome')->render());
-        $this->assertEquals('bar', $this->views->make('tenant::welcome')->render());
+        $this->assertNotEquals("bar\n", $this->views->make('welcome')->render());
+        $this->assertEquals("bar\n", $this->views->make('tenant::welcome')->render());
     }
 }


### PR DESCRIPTION
Laravel 5.8.5^ changed the filesystem slightly. This has caused errors in our tests for basically no reason.

This quick fix simply fixes the values to a point where they should match correctly.