### PR TITLE
Quick Webserver Config Fix

### DIFF
--- a/assets/configs/webserver.php
+++ b/assets/configs/webserver.php
@@ -110,7 +110,7 @@ return [
         /**
          * The php sock to be used.
          */
-        'php-sock' => 'unix:/var/run/php/php7.1-fpm.sock',
+        'php-sock' => 'unix:/var/run/php/php7.3-fpm.sock',
 
         /**
          * Define the ports of your nginx service.


### PR DESCRIPTION
Simply because the config references a PHP version that we don't support anymore.
Updated the config to a more recent version.

This shouldn't break anything, it doesn't actually fix something, it's just cleaner.