### PR TITLE
#767 - MediaController - Images not working

### DIFF
--- a/src/Controllers/MediaController.php
+++ b/src/Controllers/MediaController.php
@@ -42,6 +42,7 @@ class MediaController
         $path = "media/$path";
 
         if ($this->directory->exists($path)) {
+            ob_end_clean();
             return response($this->directory->get($path))
                 ->header('Content-Type', Storage::disk('tenant')->mimeType($path));
         }


### PR DESCRIPTION
Laravel framework might be introducing whitespace which might be ruining the `header()` function.

Use `ob_end_clean()` before our first `header()` call to remove any extra whitespace.

Closes [#767 - MediaController - Images not working](https://github.com/hyn/multi-tenant/issues/767)