### PR TITLE
Override Default Model Connection

### DIFF
--- a/src/Traits/UsesSystemConnection.php
+++ b/src/Traits/UsesSystemConnection.php
@@ -20,6 +20,6 @@ trait UsesSystemConnection
 {
     public function getConnectionName()
     {
-        return app(Connection::class)->systemName();
+        return $this->connection ?: app(Connection::class)->systemName();
     }
 }

--- a/src/Traits/UsesTenantConnection.php
+++ b/src/Traits/UsesTenantConnection.php
@@ -20,6 +20,6 @@ trait UsesTenantConnection
 {
     public function getConnectionName()
     {
-        return app(Connection::class)->tenantName();
+        return $this->connection ?: app(Connection::class)->tenantName();
     }
 }

--- a/tests/unit-tests/Models/SystemModelTest.php
+++ b/tests/unit-tests/Models/SystemModelTest.php
@@ -29,4 +29,20 @@ class SystemModelTest extends Test
         $this->assertEquals($model->getConnectionName(), $this->connection->systemName());
         $this->assertEquals($model->getConnection(), $this->connection->system());
     }
+
+    /**
+     * @test
+     */
+    public function can_override_connection()
+    {
+        $model = (new SystemExtend())->setConnection($this->connection->tenantName());
+
+        $this->assertEquals($model->getConnectionName(), $this->connection->tenantName());
+
+        $this->setUpHostnames(true);
+        $this->setUpWebsites(true, true);
+        $this->activateTenant();
+
+        $this->assertEquals($model->getConnection(), $this->connection->get());
+    }
 }

--- a/tests/unit-tests/Models/TenantModelTest.php
+++ b/tests/unit-tests/Models/TenantModelTest.php
@@ -34,4 +34,20 @@ class TenantModelTest extends Test
 
         $this->assertEquals($model->getConnection(), $this->connection->get());
     }
+
+    /**
+     * @test
+     */
+    public function can_override_connection()
+    {
+        $model = (new TenantExtend)->setConnection($this->connection->systemName());
+
+        $this->assertEquals($model->getConnectionName(), $this->connection->systemName());
+
+        $this->setUpHostnames(true);
+        $this->setUpWebsites(true, true);
+        $this->activateTenant();
+
+        $this->assertEquals($model->getConnection(), $this->connection->system());
+    }
 }


### PR DESCRIPTION
Allows overriding the connection set by the traits ```UsesTenantConnection``` and ```UsesSystemConnection```.

### Use Case

We have an ```Address``` model used with several other models in our tenant dbs. Our customers, stored in the system db also have an address. We ideally do not want to create a second identical model.

Tried using ```Address::on('...')->...``` as suggested [here](https://github.com/tenancy/multi-tenant/issues/241#issuecomment-327406281). This doesn't currently work if the model has either of the above traits.