### PR TITLE
Fix parsing of url scheme in UpdateAppUrl listener

### DIFF
--- a/src/Listeners/URL/UpdateAppUrl.php
+++ b/src/Listeners/URL/UpdateAppUrl.php
@@ -34,7 +34,7 @@ class UpdateAppUrl
     public function force($event)
     {
         if (config('tenancy.hostname.update-app-url', false)) {
-            $scheme = optional(request())->getScheme() ?? parse_url(config('app.url', PHP_URL_SCHEME));
+            $scheme = optional(request())->getScheme() ?? parse_url(config('app.url'), PHP_URL_SCHEME);
 
             /** @var Hostname $hostname */
             $hostname = $event->hostname ?? $event->website->hostnames->first();


### PR DESCRIPTION
The parenthesis was at the wrong place making PHP_URL_SCHEME the fallback for the app.url config variable.