### PR TITLE
Fix issue that prevented multiple hostnames to work properly

### DIFF
--- a/src/Listeners/URL/UpdateAppUrl.php
+++ b/src/Listeners/URL/UpdateAppUrl.php
@@ -37,7 +37,9 @@ class UpdateAppUrl
             $scheme = optional(request())->getScheme() ?? parse_url(config('app.url'), PHP_URL_SCHEME);
 
             /** @var Hostname $hostname */
-            $hostname = $event->hostname ?? $event->website->hostnames->first();
+            $hostname = $event->hostname
+                ?? $event->website->hostnames->firstWhere('fqdn', optional(request())->getHost())
+                ?? $event->website->hostnames->first();
 
             if ($hostname) {
                 $url = sprintf('%s://%s', $scheme, $hostname->fqdn);


### PR DESCRIPTION
Fixes #750 by checking the request's host to find the actual hostname instead of always getting the first one from the database.