### PR TITLE
Use entire request URI instead of only path when forcing HTTPS

### DIFF
--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -95,7 +95,7 @@ class HostnameActions
     {
         $this->emitEvent(new Secured($hostname));
 
-        return $this->redirect->secure($request->path());
+        return $this->redirect->secure($request->getRequestUri());
     }
 
     /**


### PR DESCRIPTION
Query parameters are stripped from the (secure) URL when using `$request->path()`. I changed it to `$request->getRequestUri()` to make sure query parameters are included.

**Before**
`http://example.com/page?foo=bar -> https://example.com/page`

**After**
`http://example.com/page?foo=bar -> https://example.com/page?foo=bar`