### PR TITLE
Set a limit on explode() in RunCommand

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -58,14 +58,14 @@ class RunCommand extends Command
 
         $options = collect($this->option('option') ?? [])
             ->mapWithKeys(function ($value, $key) {
-                list($key, $value) = explode('=', $value);
+                list($key, $value) = explode('=', $value, 2);
 
                 return ["--$key" => $value];
             })
             ->merge($this->option('argument') ?? [])
             ->mapWithKeys(function ($value, $key) {
                 if (!Str::startsWith($key, '--')) {
-                    list($key, $value) = explode('=', $value);
+                    list($key, $value) = explode('=', $value, 2);
                 }
 
                 return [$key => $value];


### PR DESCRIPTION
I was implementing this feature for my package and took some inspiration from how you handle passing options/args to the command. Thought I'd contribute back.

If you use a limit on `explode()`, it will let you have a `=` in the value, rather than just cutting `--argument="subject=foo=bar"` into `'--subject' => 'foo'`.