### PR TITLE
Force the default connection to 'tenant' on tenancy:run with --tenant

### DIFF
--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -29,7 +29,7 @@ class RunCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'tenancy:run {run : The artisan command to run for the tenants} 
+    protected $signature = 'tenancy:run {run : The artisan command to run for the tenants}
         {--tenant=* : The tenant(s) to run the command for}
         {--argument=* : Arguments to pass onto the command}
         {--option=* : Options to pass onto the command}
@@ -54,6 +54,7 @@ class RunCommand extends Command
 
         if ($ids = $this->option('tenant')) {
             $query->whereIn('id', $ids);
+            config(['database.default' => 'tenant']);
         }
 
         $options = collect($this->option('option') ?? [])


### PR DESCRIPTION
This pull request forces the default connection to 'tenant' for Artisan commands called with `php artisan tenancy:run` when `--tenant` option is present as it's suggested in [the documentation](https://tenancy.dev/docs/hyn/5.4/connections#forcing-the-connection). 

Since packages like `cartalyst/sentry` might contain models and can be directly called from Artisan commands for tenants, it seems like a necessity to force the connection with `config(['database.default' => 'tenant']);` in here.