### PR TITLE
Downgrade MariaDB to 10.3 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,11 @@ references:
         name: mysql2
         environment: *mysql_environment
     mariadb: &mariadb
-        image: mariadb:latest
+        image: mariadb:10.3.17-bionic
         name: mariadb
         environment: *mysql_environment
     mariadb2: &mariadb2
-        image: mariadb:latest
+        image: mariadb:10.3.17-bionic
         name: mariadb2
         environment: *mysql_environment
     pgsql: &pgsql


### PR DESCRIPTION
This fixes the current breaking builds by downgrading the MariaDB image to 10.3 in CircleCI.
It can be changed back to `:latest` after this package's [MariaDB Generator](https://github.com/tenancy/multi-tenant/blob/963987bd90266b3f7d2d0e9af35a97d0d346f8be/src/Generators/Webserver/Database/Drivers/MariaDB.php#L115) is updated.

Related: https://github.com/tenancy/multi-tenant/issues/826