### PR TITLE
Move registration of FlushHostnameCache to TenancyServiceProvider::boot 

### DIFF
--- a/src/Providers/TenancyProvider.php
+++ b/src/Providers/TenancyProvider.php
@@ -60,6 +60,8 @@ class TenancyProvider extends ServiceProvider
     public function boot()
     {
         $this->bootCommands();
+
+        $this->bootObservers();
     }
 
     protected function registerModels()
@@ -68,8 +70,11 @@ class TenancyProvider extends ServiceProvider
 
         $this->app->bind(HostnameContract::class, $config['hostname']);
         $this->app->bind(WebsiteContract::class, $config['website']);
+    }
 
-        forward_static_call([$config['hostname'], 'observe'], FlushHostnameCache::class);
+    protected function bootObservers()
+    {
+        forward_static_call([$this->app['config']['tenancy.models.hostname'], 'observe'], FlushHostnameCache::class);
     }
 
     protected function registerProviders()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I moved the registration of `FlushHostnameCache` to `TenancyServiceProvider::boot`.

## Motivation and context

The event dispatcher, which is required for model events, is only available in the boot method of a service provider. This event dispatcher is setup in `\Illuminate\Database\DatabaseServiceProvider::boot`. Registering an event observer earlier will cause the model to be booted too early when it has no event dispatcher. A model will only boot once, so if the consumer has custom logic in his model boot method that requires an event dispatcher, that functionality is also silently broken (that's how I discovered this issue).

### TL;DR
`FlushHostnameCache` is not activated.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
