### PR TITLE
access modifier of drivers method from private to protected for easy override on DatabaseDriverProvider

### DIFF
--- a/src/Providers/Tenants/DatabaseDriverProvider.php
+++ b/src/Providers/Tenants/DatabaseDriverProvider.php
@@ -32,7 +32,7 @@ class DatabaseDriverProvider extends ServiceProvider
         $this->app->singleton(DatabaseDriverFactory::class);
     }
 
-    private function drivers()
+    protected function drivers()
     {
         $isPgsqlSchema = config('tenancy.db.tenant-division-mode') === Connection::DIVISION_MODE_SEPARATE_SCHEMA;
         


### PR DESCRIPTION
In order to override the database driver classes provided by the package, one could extend the DatabaseDriverProvider and override the `drivers` method. At the moment, this method is "private", therefore unable to override. This pull request changes its access modifier from 'private' to 'protected'.