### PR TITLE
reset to default configuration when tenant identified

### DIFF
--- a/src/Listeners/Filesystem/ResetConfigs.php
+++ b/src/Listeners/Filesystem/ResetConfigs.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/hyn/multi-tenant
+ */
+
 namespace Hyn\Tenancy\Listeners\Filesystem;
 
 use Hyn\Tenancy\Abstracts\WebsiteEvent;
@@ -15,7 +27,8 @@ class ResetConfigs
         $events->listen([Identified::class, Switched::class], [$this, 'reset']);
     }
 
-    public function reset(WebsiteEvent $event){
+    public function reset(WebsiteEvent $event)
+    {
         if($event->website)
         {
             config(app()->call(ConfigurationLoader::class . '@reset'));

--- a/src/Listeners/Filesystem/ResetConfigs.php
+++ b/src/Listeners/Filesystem/ResetConfigs.php
@@ -30,7 +30,6 @@ class ResetConfigs
     public function reset(WebsiteEvent $event)
     {
         if ($event->website) {
-        {
             config(app()->call(ConfigurationLoader::class . '@reset'));
         }
     }

--- a/src/Listeners/Filesystem/ResetConfigs.php
+++ b/src/Listeners/Filesystem/ResetConfigs.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Hyn\Tenancy\Listeners\Filesystem;
+
+use Hyn\Tenancy\Abstracts\WebsiteEvent;
+use Hyn\Tenancy\Events\Websites\Identified;
+use Hyn\Tenancy\Events\Websites\Switched;
+use Hyn\Tenancy\Services\ConfigurationLoader;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class ResetConfigs
+{
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen([Identified::class, Switched::class], [$this, 'reset']);
+    }
+
+    public function reset(WebsiteEvent $event){
+        if($event->website)
+        {
+            config(app()->call(ConfigurationLoader::class . '@reset'));
+        }
+    }
+}

--- a/src/Listeners/Filesystem/ResetConfigs.php
+++ b/src/Listeners/Filesystem/ResetConfigs.php
@@ -29,7 +29,7 @@ class ResetConfigs
 
     public function reset(WebsiteEvent $event)
     {
-        if($event->website)
+        if ($event->website) {
         {
             config(app()->call(ConfigurationLoader::class . '@reset'));
         }

--- a/src/Providers/Tenants/EventProvider.php
+++ b/src/Providers/Tenants/EventProvider.php
@@ -39,6 +39,8 @@ class EventProvider extends ServiceProvider
         Generators\Filesystem\DirectoryGenerator::class,
         // Sets the uuid value on a website based on tenancy configuration.
         Listeners\WebsiteUuidGeneration::class,
+        // Reset default configuration
+        Listeners\Filesystem\ResetConfigs::class,
         // Loads custom configuration folder for tenant.
         Listeners\Filesystem\LoadsConfigs::class,
         // Adds tenant specific routes.

--- a/src/Services/ConfigurationLoader.php
+++ b/src/Services/ConfigurationLoader.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/hyn/multi-tenant
+ */
+
 namespace Hyn\Tenancy\Services;
 
 use Illuminate\Contracts\Foundation\Application;

--- a/src/Services/ConfigurationLoader.php
+++ b/src/Services/ConfigurationLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Hyn\Tenancy\Services;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+
+class ConfigurationLoader extends LoadConfiguration
+{
+    public function reset(Application $app)
+    {
+        return $this->items($app);
+    }
+
+    protected function items(Application $app)
+    {
+        $cached = $app->getCachedConfigPath();
+
+        if (file_exists($cached)) {
+            return require $cached;
+        }
+
+        $items = [];
+
+        foreach ($this->getConfigurationFiles($app) as $key => $file) {
+            $items[$key] = require $file;
+        }
+
+        return $items;
+    }
+}

--- a/tests/unit-tests/Filesystem/ResetConfigsTest.php
+++ b/tests/unit-tests/Filesystem/ResetConfigsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the hyn/multi-tenant package.
+ *
+ * (c) Daniël Klabbers <daniel@klabbers.email>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://tenancy.dev
+ * @see https://github.com/hyn/multi-tenant
+ */
+
+namespace Hyn\Tenancy\Tests\Filesystem;
+
+use Hyn\Tenancy\Environment;
+use Hyn\Tenancy\Events\Websites\Identified;
+use Hyn\Tenancy\Models\Website;
+use Hyn\Tenancy\Tests\Test;
+use Hyn\Tenancy\Website\Directory;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Queue;
+
+class ConfigJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $website_id;
+
+    public $appName;
+
+    public function __construct($website_id = null)
+    {
+        $this->website_id = $website_id;
+    }
+
+    public function handle()
+    {
+        $website = Website::find($this->website_id);
+        if ($website)
+        {
+            app(Environment::class)->tenant($website);
+        }
+        $this->appName = config('app.name');
+    }
+}
+
+class ResetConfigsTest extends Test
+{
+    /**
+     * @var Directory
+     */
+    protected $directory;
+
+    /**
+     * @var \Hyn\Tenancy\Contracts\Website
+     */
+    protected $secondWebsite;
+
+    protected function duringSetUp(Application $app)
+    {
+        $this->setUpHostnames(true);
+        $this->setUpWebsites(true, true);
+
+        $this->directory = $app->make(Directory::class);
+        $this->directory->setWebsite($this->website);
+
+        $this->secondWebsite = new Website;
+        $this->websites->create($this->secondWebsite);
+
+        $secondDirectory = $this->app->make(Directory::class);
+        $secondDirectory->setWebsite($this->secondWebsite);
+        $secondDirectory->makeDirectory('config');
+        $secondDirectory->put('config/app.php', <<<EOM
+<?php
+return ['name' => 'My name on second tenant'];
+EOM
+        );
+    }
+    /**
+     * @test
+     */
+    public function config_is_reset_when_tenant_switched_identified()
+    {
+        config()->set('app.name', 'Laravel');
+
+        $job = new ConfigJob($this->website->id);
+        $secondJob = new ConfigJob($this->secondWebsite->id);
+
+        $secondJob->handle();
+        $job->handle();
+
+        $this->assertEquals('Laravel', $job->appName);
+        $this->assertEquals('My name on second tenant', $secondJob->appName);
+    }
+}

--- a/tests/unit-tests/Filesystem/ResetConfigsTest.php
+++ b/tests/unit-tests/Filesystem/ResetConfigsTest.php
@@ -45,8 +45,7 @@ class ConfigJob implements ShouldQueue
     public function handle()
     {
         $website = Website::find($this->website_id);
-        if ($website)
-        {
+        if ($website) {
             app(Environment::class)->tenant($website);
         }
         $this->appName = config('app.name');


### PR DESCRIPTION
This pull request allows you to fix a problem on configuration values when jobs are dispatched randomly on several tenants.
Indeed, the configuration being injected into the AbstractTenantDirectoryListener class, it is kept in memory. This means that when a job is started on a tenant which has a specific configuration and then another job which does not have a specific configuration then we have
on the first tenant the configuration values of the second tenant.

Goal is to reset configuration by default using a listener and when website is identified or switched then configuration is reset

If you comment the registration of Listeners\Filesystem\ResetConfigs::class in EventProvider and you run my test, you will see that the value of app.name is kept from one part to another tenant.