### PR TITLE
Add laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,17 @@
         "phpseclib/phpseclib": "~2.0",
         "doctrine/dbal": "~2.5",
         "ramsey/uuid": "^3.5",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "symfony/dom-crawler": "~3.1",
-        "laravel/laravel": "^6.0",
+        "laravel/laravel": "dev-develop",
         "mockery/mockery": "^1.0",
         "fzaninotto/faker": "^1.8"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Hyn\\Tenancy\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,10 @@
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "symfony/dom-crawler": "~3.1",
-        "laravel/laravel": "dev-develop",
+        "laravel/laravel": "^7.0",
         "mockery/mockery": "^1.0",
         "fzaninotto/faker": "^1.8"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Hyn\\Tenancy\\": "src/"

--- a/src/Listeners/Servant.php
+++ b/src/Listeners/Servant.php
@@ -99,7 +99,7 @@ class Servant
 
                 if ($generator instanceof SavesToPath) {
                     $original = $event->website->newInstance();
-                    $original->setRawAttributes($event->website->getOriginal());
+                    $original->setRawAttributes($event->website->getRawOriginal());
                     $path = $generator->targetPath($original);
                 }
 

--- a/tests/unit-tests/Database/ConnectionTest.php
+++ b/tests/unit-tests/Database/ConnectionTest.php
@@ -96,7 +96,7 @@ class ConnectionTest extends Test
     public function override_to_tenant_connection()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Database [tenant] not configured.');
+        $this->expectExceptionMessage('Database connection [tenant] not configured.');
 
         config(['tenancy.db.force-tenant-connection-of-models' => [NonExtend::class]]);
 


### PR DESCRIPTION
This PR aims to add support for upcoming Laravel 7

Some stuffs still need to be done : 
- restore `laravel/laravel` to a stable version when it will be released
- drop `"minimum-stability": "dev"` and `"prefer-stable": true` from `composer.json`

`Model::getOriginal()` has been changed in Laravel 7 (see [upgrade guide](https://laravel.com/docs/master/upgrade)). It is used in 3 places here : 
- `Hyn\Tenancy\Listeners\Servant::touch()` : getOriginal has been changed to getRawOriginal
- `Hyn\Tenancy\Repositories\HostnameRepository::update`
- `Hyn\Tenancy\Repositories\WebsiteRepository::update`

I did not change getOriginal to getRawOriginal because I think it could be convenient to get casted attributes instead of raw attributes. It can be changed if you think we would rather keep the way it was.