### PR TITLE
Fix the 'tenancy:migration:fresh --seed' command

### DIFF
--- a/src/Database/Console/Migrations/FreshCommand.php
+++ b/src/Database/Console/Migrations/FreshCommand.php
@@ -69,9 +69,9 @@ class FreshCommand extends BaseCommand
      */
     protected function getOptions()
     {
-        foreach ($options = parent::getOptions() as $option) {
-            if ($option[0] === 'seeder') {
-                $option[4] = config('tenancy.db.tenant-seed-class', null);
+        foreach ($options = parent::getOptions() as $key => $option) {
+            if ($options[$key][0] === 'seeder') {
+                $options[$key][4] = config('tenancy.db.tenant-seed-class', null);
             }
         }
 

--- a/src/Database/Console/Migrations/FreshCommand.php
+++ b/src/Database/Console/Migrations/FreshCommand.php
@@ -69,9 +69,10 @@ class FreshCommand extends BaseCommand
      */
     protected function getOptions()
     {
-        foreach ($options = parent::getOptions() as $key => $option) {
-            if ($options[$key][0] === 'seeder') {
-                $options[$key][4] = config('tenancy.db.tenant-seed-class', null);
+        $options = parent::getOptions();
+        foreach ($options as &$option) {
+            if ($option[0] === 'seeder') {
+                $option[4] = config('tenancy.db.tenant-seed-class', null);
             }
         }
 


### PR DESCRIPTION
back then, it doesnt mutate the `$options` variable,
since the expected is mutating the variable.

this PR just fix this behavior.