### PR TITLE
Addedd missing port to url generation when update-app-url is set to true

### DIFF
--- a/src/Listeners/URL/UpdateAppUrl.php
+++ b/src/Listeners/URL/UpdateAppUrl.php
@@ -35,6 +35,10 @@ class UpdateAppUrl
     {
         if (config('tenancy.hostname.update-app-url', false)) {
             $scheme = optional(request())->getScheme() ?? parse_url(config('app.url'), PHP_URL_SCHEME);
+            $port = optional(request())->getPort();
+            if (in_array($port, [80, 443])) {
+                $port = null;
+            }
 
             /** @var Hostname $hostname */
             $hostname = $event->hostname
@@ -42,7 +46,7 @@ class UpdateAppUrl
                 ?? $event->website->hostnames->first();
 
             if ($hostname) {
-                $url = sprintf('%s://%s', $scheme, $hostname->fqdn);
+                $url = sprintf('%s://%s', $scheme, $hostname->fqdn.($port ? ":$port" : ""));
 
                 config([
                     'app.url' => $url


### PR DESCRIPTION
When a different port from from 80 or 443 is used in the url (generally on dev environments) the port was not added to the generated urls.
This should be a safe fix considering that the url generator behaviour is not altered when ports 80 or 443 are used.
Solving issue on ticket #905 