### PR TITLE
Possibility to set middleware to tenant routes

### DIFF
--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -355,6 +355,12 @@ return [
              * Prefix all tenant routes.
              */
             'prefix' => null,
+            
+            /**
+             * Allows adding middlewares tenant specific routes.
+             * Accept array or string value
+             */
+            'middleware' => ['web'],
         ],
         'trans' => [
             /**

--- a/assets/configs/tenancy.php
+++ b/assets/configs/tenancy.php
@@ -358,9 +358,9 @@ return [
             
             /**
              * Allows adding middlewares tenant specific routes.
-             * Accept array or string value
+             * Accepted values array|string|null
              */
-            'middleware' => ['web'],
+            'middleware' => null,
         ],
         'trans' => [
             /**

--- a/src/Listeners/Filesystem/LoadsRoutes.php
+++ b/src/Listeners/Filesystem/LoadsRoutes.php
@@ -50,8 +50,12 @@ class LoadsRoutes extends AbstractTenantDirectoryListener
         $router = app('router');
 
         $prefix = config('tenancy.folders.routes.prefix', '');
+        $middleware = config('tenancy.folders.routes.middleware', []) ?: [];
 
-        $router->group(['prefix' => $prefix], function ($router) use ($path) {
+        $router->group([
+            'prefix' => $prefix,
+            'middleware' => $middleware,
+        ], function ($router) use ($path) {
             return $this->directory()->getRequire($path);
         });
     }


### PR DESCRIPTION
This PR add possibility to set middlewares to tenant specific routes.

Reason
- In my tenant specific views when I try to access global variable `$errors` it's undefined. That is because dynamic loaded `routes.php` file is missing `web` group middleware. Applying the changes from that PR that problem is solved.