### PR TITLE
Fix HostnameActions aborting request to the Sytem site

### DIFF
--- a/src/Middleware/HostnameActions.php
+++ b/src/Middleware/HostnameActions.php
@@ -68,8 +68,12 @@ class HostnameActions
             if (!$request->secure() && $hostname->force_https) {
                 return $this->secure($hostname, $request);
             }
-        } else {
-            $this->abort($request);
+        } 
+        
+        else {
+            if ($request->getHttpHost() !== config('tenancy.hostname.default')) {
+                $this->abort($request);
+            }
         }
 
         return $next($request);


### PR DESCRIPTION
Adding a check to check if the request is for the System by matching the http host against user configured default hostname and only abort if it doesn't match