### PR TITLE
Laravel 10, 11 - PHP 8.1, 8.2, 8.3 - Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
         "docs": "https://tenancy.dev"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.0|^8.1|^8.2|^8.3",
         "doctrine/dbal": "~2.5|~3.0",
         "ramsey/uuid": "^4.0",
-        "laravel/framework": "^9.0|^10.0"
+        "laravel/framework": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.12",
-        "laravel/laravel": "^9.0|^10.0",
+        "laravel/laravel": "^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^9.0",
         "symfony/dom-crawler": "~3.1"


### PR DESCRIPTION
Add Laravel 10 and 11.
Add PHP 8.1, 8.2, and 8.3.
Laravel 11 requires PHP 8.3.